### PR TITLE
로그인/회원가입 API 및 JWT 토큰 기반 보안 설정 추가

### DIFF
--- a/.github/.coderabbit.yml
+++ b/.github/.coderabbit.yml
@@ -9,32 +9,83 @@ ignore:
 # PR의 전체적인 요약을 생성할 때의 지침
 summarize:
     instructions: |
-        이 PR의 핵심적인 변경 사항을 3가지 주요 항목으로 요약해 주세요.
-        각 항목은 한 문장으로 명확하게 작성하고, 한국어로 응답해 주세요.
+      Summarize the core changes of this PR in five main bullet points.
+      Each point should be a single, clear sentence.
+      All your responses must be in Korean.
+
+auto_title:
+  # PR 본문에 '@coderabbitai 제목' 이라고 코멘트를 달면 제목 생성을 트리거합니다.
+  placeholder: "@coderabbitai 제목"
 
 # 라인별 코드 리뷰를 생성할 때의 지침 (가장 중요!)
 review:
-    instructions: |
-        당신은 우리 팀의 시니어 백엔드 개발자입니다.
-        당신은 헥사고날 아키텍처, DDD, 클린 코드 원칙의 전문가이며, 코틀린 언어를 매우 사랑합니다.
-        ktlint가 잡지 못하는 더 깊이 있는 리뷰를 제공해 주세요.
-        모든 제안은 정중하고 명확한 근거를 바탕으로 한국어로 작성해 주세요.
+  # 리뷰의 톤을 설정합니다. 'chill'은 친근하고 교육적인 톤을 권장합니다.
+  profile: chill
 
-        **[아키텍처 및 설계 원칙]**
-        1.  **의존성 규칙:** 도메인/애플리케이션 계층이 어댑터 계층을 참조하는 코드가 있다면 반드시 지적해 주세요. (예: domain -> adapter import)
-        2.  **포트와 어댑터:** 컨트롤러는 반드시 UseCase 인터페이스(Input Port)에만 의존해야 합니다. 서비스 구현체에 직접 의존하면 안 됩니다.
-        3.  **데이터 흐름:** 외부 요청(Request DTO)이 컨트롤러에서 내부 데이터(Command) 객체로 잘 변환되어 UseCase로 전달되는지 확인해 주세요.
-        4.  **도메인 로직:** 비즈니스 규칙이나 로직이 서비스 계층이 아닌 도메인 모델 안에 있는지 확인해 주세요. 서비스는 오케스트레이션 역할에 집중해야 합니다.
+  # 리뷰에서 제외할 파일 경로를 지정합니다.
+  path_filters:
+    - "!**/resources/**"
+    - "!**/build.gradle.kts"
+    - "!**/*.md"
 
-        **[코틀린 특화 리뷰]**
-        1.  **Idiomatic Kotlin:** Java 스타일 대신 코틀린의 스코프 함수(let, run, apply), 확장 함수, 데이터 클래스 등을 더 효과적으로 사용할 수 있는 부분을 제안해 주세요.
-        2.  **Null 안전성:** `!!` 사용을 지양하고, `?.let` 이나 `?:` (Elvis 연산자)를 사용한 안전한 처리를 권장해 주세요.
-        3.  **불변성:** `var` 대신 `val`을, `MutableList` 대신 `List`를 사용하도록 제안하여 불변성을 높이는 방향을 제시해 주세요.
+  # ★★★ 파일 경로별 특별 지침 (가장 강력한 기능) ★★★
+  # 파일의 종류에 따라 AI가 더 집중해서 봐야 할 부분을 알려줍니다.
+  path_instructions:
+    - path: "**/adapter/in/web/**/*.kt" # 컨트롤러 계층
+      instructions: |
+        Focus on API design principles.
+        1.  Check if the API endpoint follows RESTful conventions (e.g., plural nouns for resources).
+        2.  Ensure that Request DTOs are properly converted to internal Command objects before calling the UseCase.
+        3.  The controller should be thin and only responsible for handling HTTP requests/responses and delegating tasks to the application layer.
 
-        **[성능 및 쿼리]**
-        1.  **N+1 문제:** 루프 안에서 JPA/QueryDSL 쿼리를 실행하는 코드를 발견하면, Fetch Join 이나 DTO 프로젝션을 사용한 해결책을 제시해 주세요.
-        2.  **쿼리 효율성:** 비효율적인 서브쿼리나 조인문을 더 효율적으로 개선할 수 있는 방법을 제안해 주세요.
+    - path: "**/application/service/**/*.kt" # 서비스 계층
+      instructions: |
+        Focus on the orchestration role of the service.
+        1.  The service must implement a UseCase interface (Input Port).
+        2.  It should not contain any core business logic; this logic must reside in the domain model.
+        3.  The service orchestrates calls to domain models and ports (repositories, etc.).
 
-        **[기타]**
-        1.  메소드나 클래스의 이름이 그 역할을 명확하게 드러내는지 확인해 주세요.
-        2.  복잡한 로직은 더 작은 메소드로 분리하도록 제안해 주세요.
+    - path: "**/domain/**/*.kt" # 도메인 계층
+      instructions: |
+        Focus on rich domain models and business logic.
+        1.  Criticize anemic domain models. Business rules and state transitions should be encapsulated within the domain entities.
+        2.  Ensure the domain layer has no dependencies on outer layers (application, adapter). Check for invalid `import` statements.
+
+    - path: "**/adapter/out/persistence/**/*.kt" # 영속성 계층
+      instructions: |
+        Focus on performance and proper data mapping.
+        1.  Look for potential N+1 query problems and suggest solutions like fetch joins or DTO projections.
+        2.  Ensure that JPA entities are correctly mapped to and from domain models. The persistence adapter is the boundary for this conversion.
+
+  # ★★★ AI 리뷰어의 페르소나 및 전역 리뷰 지침 ★★★
+  # 모든 파일에 공통으로 적용되는 핵심 리뷰 규칙입니다.
+  instructions: |
+    You are a Senior Backend Developer and a meticulous Software Architect on our team.
+    You have a deep understanding of Hexagonal Architecture, Domain-Driven Design (DDD), and Clean Code principles. You are an expert in Kotlin.
+    Your goal is to provide reviews that go beyond what a simple linter like ktlint can catch.
+    Every suggestion must be constructive, polite, and accompanied by a clear reason explaining "why" it's a better approach, providing educational value.
+    All your responses must be in Korean.
+
+    **[Architectural Principles]**
+    1.  **Dependency Rule:** Strictly enforce that the domain/application layers must NOT depend on the adapter layer. Point out any `import` statement from an adapter package within the domain or application packages.
+    2.  **Ports & Adapters:** Controllers (Inbound Adapters) must only depend on UseCase interfaces (Input Ports), not on concrete service implementations.
+
+    **[Kotlin-Specific Review]**
+    1.  **Idiomatic Kotlin:** Suggest replacing Java-style code with idiomatic Kotlin features like scope functions (let, run, apply), extension functions, and data classes where appropriate.
+    2.  **Null Safety:** Strongly discourage the use of `!!` (not-null assertion). Recommend safer alternatives like `?.let` or the Elvis operator `?:`.
+    3.  **Immutability:** Advocate for immutability. Suggest replacing `var` with `val` and `MutableList` with `List` whenever possible.
+
+    **[Clean Code Principles]**
+    1.  **Meaningful Names:** Variable, function, and class names must be clear, intention-revealing, and unambiguous. If a name is poor, suggest a better one.
+    2.  **Single Responsibility Principle (SRP):** A function or class should do one thing and do it well. If a function is too long or a class has too many responsibilities, recommend refactoring it into smaller, more focused units.
+    3.  **Don't Repeat Yourself (DRY):** Point out duplicated code blocks and suggest extracting them into a shared function or class.
+    4.  **Avoid Magic Numbers/Strings:** Hard-coded values should be extracted into well-named constants.
+    5.  **Comments:** Comments should explain the "why," not the "what." Redundant comments that just restate what the code does should be removed.
+    6.  **Error Handling:** `try-catch` blocks should not swallow exceptions. They should handle specific exceptions and avoid overly broad `catch (e: Exception) {}` blocks.
+
+    **[Testing & Stability]**
+    1.  **Missing Tests:** If a new public method or significant business logic is added without corresponding tests, strongly recommend adding them.
+    2.  **Test Naming:** Test method names should be descriptive, following a clear pattern like `given-when-then` or a sentence structure.
+
+    **[Security]**
+    1.  **Sensitive Data Logging:** Warn if you find code that might log sensitive information like passwords, personal details, or API keys.

--- a/.github/.coderabbit.yml
+++ b/.github/.coderabbit.yml
@@ -22,6 +22,7 @@ review:
   # 리뷰의 톤을 설정합니다. 'chill'은 친근하고 교육적인 톤을 권장합니다.
   profile: chill
 
+  high_level_summary: true
   # 리뷰에서 제외할 파일 경로를 지정합니다.
   path_filters:
     - "!**/resources/**"
@@ -89,3 +90,14 @@ review:
 
     **[Security]**
     1.  **Sensitive Data Logging:** Warn if you find code that might log sensitive information like passwords, personal details, or API keys.
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    ignore_title_keywords: [ ]
+    labels: [ ]
+    drafts: false
+    base_branches: [ ]
+  chat:
+    auto_reply: true
+  poem: true

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/config/SecurityConfig.kt
@@ -33,7 +33,9 @@ class SecurityConfig(
             .authorizeHttpRequests { requests ->
                 requests
                     .requestMatchers(
-                        "/swagger-ui/**"
+                        "/swagger-ui/**",
+                        "/auth/admin/login",
+                        "/auth/admin/sign-up"
                     ).permitAll()
                     .anyRequest().authenticated()
             }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetails.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetails.kt
@@ -1,28 +1,24 @@
 package com.soomsoom.backend.adapter.`in`.security.service
 
-import com.soomsoom.backend.application.port.out.user.UserPort
-import org.springframework.security.core.userdetails.User
+import com.soomsoom.backend.domain.user.model.Account
+import com.soomsoom.backend.domain.user.model.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
-import org.springframework.security.core.userdetails.UserDetailsService
-import org.springframework.security.core.userdetails.UsernameNotFoundException
-import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
-@Service
 class CustomUserDetails(
-    private val userPort: UserPort,
-) : UserDetailsService {
-
-    @Transactional(readOnly = true)
-    override fun loadUserByUsername(username: String): UserDetails {
-        val user = (
-            userPort.findById(username.toLong())
-                ?: throw UsernameNotFoundException("해당 유저를 찾을 수 없습니다: $username")
-            )
-
-        return User.builder()
-            .username(user.id.toString())
-            .roles(user.role.name)
-            .build()
+    private val user: User
+) : UserDetails {
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
+        return mutableListOf(SimpleGrantedAuthority(user.role.name))
     }
+
+    override fun getPassword(): String {
+        return (user.account as Account.IdPassword).password
+    }
+
+    override fun getUsername(): String {
+        return (user.account as Account.IdPassword).username
+    }
+
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetails.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetails.kt
@@ -7,7 +7,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
 class CustomUserDetails(
-    private val user: User
+    private val user: User,
 ) : UserDetails {
     override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
         return mutableListOf(SimpleGrantedAuthority(user.role.name))
@@ -20,5 +20,4 @@ class CustomUserDetails(
     override fun getUsername(): String {
         return (user.account as Account.IdPassword).username
     }
-
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetailsService.kt
@@ -1,0 +1,24 @@
+package com.soomsoom.backend.adapter.`in`.security.service
+
+import com.soomsoom.backend.application.port.out.user.UserPort
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CustomUserDetailsService(
+    private val userPort: UserPort,
+) : UserDetailsService {
+
+    @Transactional(readOnly = true)
+    override fun loadUserByUsername(username: String): UserDetails {
+        val user = (
+            userPort.findByUsername(username)
+                ?: throw UsernameNotFoundException("해당 유저를 찾을 수 없습니다: $username")
+            )
+
+        return CustomUserDetails(user);
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetailsService.kt
@@ -19,6 +19,6 @@ class CustomUserDetailsService(
                 ?: throw UsernameNotFoundException("해당 유저를 찾을 수 없습니다: $username")
             )
 
-        return CustomUserDetails(user);
+        return CustomUserDetails(user)
     }
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/AuthController.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/AuthController.kt
@@ -24,7 +24,7 @@ class AuthController(
     @ResponseStatus(HttpStatus.OK)
     fun adminLogin(
         @RequestBody request: AdminLoginRequest,
-    ) : TokenInfo {
+    ): TokenInfo {
         println("controller")
         return adminLoginUseCase.adminLogin(request.toCommand())
     }
@@ -33,7 +33,7 @@ class AuthController(
     @ResponseStatus(HttpStatus.CREATED)
     fun adminSignUp(
         @RequestBody request: AdminSignUpRequest,
-    ) : TokenInfo {
+    ): TokenInfo {
         return adminSignUpUserCase.adminSignUp(request.toCommand())
     }
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/AuthController.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/AuthController.kt
@@ -1,0 +1,39 @@
+package com.soomsoom.backend.adapter.`in`.web.api.auth
+
+import com.soomsoom.backend.adapter.`in`.web.api.auth.request.AdminLoginRequest
+import com.soomsoom.backend.adapter.`in`.web.api.auth.request.AdminSignUpRequest
+import com.soomsoom.backend.adapter.`in`.web.api.auth.request.toCommand
+import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
+import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminLoginUseCase
+import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminSignUpUseCase
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth")
+class AuthController(
+    private val adminLoginUseCase: AdminLoginUseCase,
+    private val adminSignUpUserCase: AdminSignUpUseCase,
+) {
+
+    @PostMapping("/admin/login")
+    @ResponseStatus(HttpStatus.OK)
+    fun adminLogin(
+        @RequestBody request: AdminLoginRequest,
+    ) : TokenInfo {
+        println("controller")
+        return adminLoginUseCase.adminLogin(request.toCommand())
+    }
+
+    @PostMapping("/admin/sign-up")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun adminSignUp(
+        @RequestBody request: AdminSignUpRequest,
+    ) : TokenInfo {
+        return adminSignUpUserCase.adminSignUp(request.toCommand())
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminLoginRequest.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminLoginRequest.kt
@@ -9,5 +9,5 @@ data class AdminLoginRequest(
 
 fun AdminLoginRequest.toCommand() = AdminLoginCommand(
     username,
-    password,
+    password
 )

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminLoginRequest.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminLoginRequest.kt
@@ -1,0 +1,13 @@
+package com.soomsoom.backend.adapter.`in`.web.api.auth.request
+
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminLoginCommand
+
+data class AdminLoginRequest(
+    val username: String,
+    val password: String,
+)
+
+fun AdminLoginRequest.toCommand() = AdminLoginCommand(
+    username,
+    password,
+)

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminSignUpRequest.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminSignUpRequest.kt
@@ -1,0 +1,10 @@
+package com.soomsoom.backend.adapter.`in`.web.api.auth.request
+
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminSignUpCommand
+
+data class AdminSignUpRequest(
+    val username: String,
+    val password: String,
+)
+
+fun AdminSignUpRequest.toCommand() = AdminSignUpCommand(username, password)

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/instructor/InstructorController.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/instructor/InstructorController.kt
@@ -1,11 +1,13 @@
 package com.soomsoom.backend.adapter.`in`.web.api.instructor
 
 import com.soomsoom.backend.adapter.`in`.web.api.instructor.request.RegisterInstructorRequest
-import com.soomsoom.backend.adapter.`in`.web.api.instructor.request.RegisterInstructorResponse
 import com.soomsoom.backend.adapter.`in`.web.api.instructor.request.toCommand
+import com.soomsoom.backend.adapter.`in`.web.api.instructor.response.RegisterInstructorResponse
 import com.soomsoom.backend.application.port.`in`.instructor.usecase.RegisterInstructorUseCase
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -14,6 +16,7 @@ class InstructorController(
 ) {
 
     @PostMapping("/instructors")
+    @ResponseStatus(HttpStatus.CREATED)
     fun register(
         @RequestBody request: RegisterInstructorRequest,
     ): RegisterInstructorResponse {

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/instructor/response/RegisterInstructorResponse.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/instructor/response/RegisterInstructorResponse.kt
@@ -1,4 +1,4 @@
-package com.soomsoom.backend.adapter.`in`.web.api.instructor.request
+package com.soomsoom.backend.adapter.`in`.web.api.instructor.response
 
 import com.soomsoom.backend.domain.instructor.model.Instructor
 

--- a/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/user/UserPersistenceAdapter.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/user/UserPersistenceAdapter.kt
@@ -19,4 +19,14 @@ class UserPersistenceAdapter(
     override fun findByDeviceId(deviceId: String): User? {
         return userJpaRepository.findByDeviceId(deviceId)?.toDomain()
     }
+
+    override fun findById(userId: Long): User? {
+        return userJpaRepository.findById(userId)
+            .map { it.toDomain() }
+            .orElse(null)
+    }
+
+    override fun findByUsername(username: String): User? {
+        return userJpaRepository.findByUsername(username)?.toDomain()
+    }
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/user/repository/jpa/UserJpaRepository.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/user/repository/jpa/UserJpaRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserJpaRepository : JpaRepository<UserJpaEntity, Long> {
     fun findByDeviceId(deviceId: String): UserJpaEntity?
+    fun findByUsername(username: String): UserJpaEntity?
 }

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/TokenInfo.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/TokenInfo.kt
@@ -1,0 +1,5 @@
+package com.soomsoom.backend.application.port.`in`.auth
+
+data class TokenInfo(
+    val accessToken: String,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/command/AdminLoginCommand.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/command/AdminLoginCommand.kt
@@ -1,0 +1,6 @@
+package com.soomsoom.backend.application.port.`in`.auth.command
+
+data class AdminLoginCommand(
+    val username: String,
+    val password: String,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/command/AdminSignUpCommand.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/command/AdminSignUpCommand.kt
@@ -1,0 +1,6 @@
+package com.soomsoom.backend.application.port.`in`.auth.command
+
+data class AdminSignUpCommand(
+    val username: String,
+    val password: String,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/usecase/AdminLoginUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/usecase/AdminLoginUseCase.kt
@@ -1,0 +1,8 @@
+package com.soomsoom.backend.application.port.`in`.auth.usecase
+
+import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminLoginCommand
+
+interface AdminLoginUseCase {
+    fun adminLogin(command: AdminLoginCommand): TokenInfo
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/usecase/AdminSignUpUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/usecase/AdminSignUpUseCase.kt
@@ -1,0 +1,9 @@
+package com.soomsoom.backend.application.port.`in`.auth.usecase
+
+import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminSignUpCommand
+
+interface AdminSignUpUseCase {
+
+    fun adminSignUp(command: AdminSignUpCommand): TokenInfo
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/out/user/UserPort.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/out/user/UserPort.kt
@@ -9,4 +9,6 @@ interface UserPort {
     fun findByDeviceId(deviceId: String): User?
 
     fun findById(userId: Long): User?
+
+    fun findByUsername(username: String): User?
 }

--- a/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminLoginService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminLoginService.kt
@@ -1,0 +1,44 @@
+package com.soomsoom.backend.application.service.auth
+
+import com.soomsoom.backend.adapter.`in`.security.provider.JwtTokenProvider
+import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminLoginCommand
+import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminLoginUseCase
+import com.soomsoom.backend.application.port.out.user.UserPort
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class AdminLoginService(
+    private val userPort: UserPort,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val authenticationManagerBuilder: AuthenticationManagerBuilder,
+) : AdminLoginUseCase {
+    override fun adminLogin(command: AdminLoginCommand): TokenInfo {
+
+
+        val authenticationToken = UsernamePasswordAuthenticationToken(command.username, command.password)
+        println(command.password)
+        val authResult = authenticationManagerBuilder.`object`.authenticate(authenticationToken)
+        println(123123123123123)
+
+        return userPort.findByUsername(authResult.name)
+            ?.let { user ->
+                UsernamePasswordAuthenticationToken(
+                    User(user.id.toString(), "", authResult.authorities),
+                    "",
+                    authResult.authorities
+                )
+            }
+            ?.let ( jwtTokenProvider::generateToken )
+            ?.let { TokenInfo(it) }
+            ?:throw UsernameNotFoundException("User not found with username: ${authResult.name}")
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminLoginService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminLoginService.kt
@@ -5,12 +5,10 @@ import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
 import com.soomsoom.backend.application.port.`in`.auth.command.AdminLoginCommand
 import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminLoginUseCase
 import com.soomsoom.backend.application.port.out.user.UserPort
-import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UsernameNotFoundException
-import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -22,8 +20,6 @@ class AdminLoginService(
     private val authenticationManagerBuilder: AuthenticationManagerBuilder,
 ) : AdminLoginUseCase {
     override fun adminLogin(command: AdminLoginCommand): TokenInfo {
-
-
         val authenticationToken = UsernamePasswordAuthenticationToken(command.username, command.password)
         println(command.password)
         val authResult = authenticationManagerBuilder.`object`.authenticate(authenticationToken)
@@ -37,8 +33,8 @@ class AdminLoginService(
                     authResult.authorities
                 )
             }
-            ?.let ( jwtTokenProvider::generateToken )
+            ?.let(jwtTokenProvider::generateToken)
             ?.let { TokenInfo(it) }
-            ?:throw UsernameNotFoundException("User not found with username: ${authResult.name}")
+            ?: throw UsernameNotFoundException("User not found with username: ${authResult.name}")
     }
 }

--- a/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminSignUpService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminSignUpService.kt
@@ -16,7 +16,7 @@ class AdminSignUpService(
     private val userPort: UserPort,
     private val passwordEncoder: PasswordEncoder,
     private val jwtTokenProvider: JwtTokenProvider,
-) : AdminSignUpUseCase{
+) : AdminSignUpUseCase {
     override fun adminSignUp(command: AdminSignUpCommand): TokenInfo {
         userPort.findByUsername(command.username)?.let {
             throw IllegalStateException("이미 존재하는 계정 이름")
@@ -25,7 +25,8 @@ class AdminSignUpService(
         return passwordEncoder.encode(command.password)
             .let { encodedPassword ->
                 println(encodedPassword)
-                User.createAdmin(command.username, encodedPassword) }
+                User.createAdmin(command.username, encodedPassword)
+            }
             .let(userPort::save)
             .let { savedUser ->
                 val authorities = listOf(SimpleGrantedAuthority(savedUser.role.name))

--- a/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminSignUpService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminSignUpService.kt
@@ -1,0 +1,42 @@
+package com.soomsoom.backend.application.service.auth
+
+import com.soomsoom.backend.adapter.`in`.security.provider.JwtTokenProvider
+import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminSignUpCommand
+import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminSignUpUseCase
+import com.soomsoom.backend.application.port.out.user.UserPort
+import com.soomsoom.backend.domain.user.model.User
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+
+@Service
+class AdminSignUpService(
+    private val userPort: UserPort,
+    private val passwordEncoder: PasswordEncoder,
+    private val jwtTokenProvider: JwtTokenProvider,
+) : AdminSignUpUseCase{
+    override fun adminSignUp(command: AdminSignUpCommand): TokenInfo {
+        userPort.findByUsername(command.username)?.let {
+            throw IllegalStateException("이미 존재하는 계정 이름")
+        }
+
+        return passwordEncoder.encode(command.password)
+            .let { encodedPassword ->
+                println(encodedPassword)
+                User.createAdmin(command.username, encodedPassword) }
+            .let(userPort::save)
+            .let { savedUser ->
+                val authorities = listOf(SimpleGrantedAuthority(savedUser.role.name))
+                val principal = org.springframework.security.core.userdetails.User(
+                    savedUser.id.toString(),
+                    "",
+                    authorities
+                )
+                UsernamePasswordAuthenticationToken(principal, "", authorities)
+            }
+            .let(jwtTokenProvider::generateToken)
+            .let { TokenInfo(it) }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,14 @@
 spring.application.name=backend
+
+spring.datasource.url=jdbc:mysql://localhost:3306/soomsoom?useSSL=false&serverTimezone=Asia/Seoul
+spring.datasource.username=root
+spring.datasource.password=root
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sqltrue
 jwt.secret= aweijfiweajflkjkljf32iojfoijslkfjiefjawefaw434
 jwt.access.expiration=3600000
+
+
+


### PR DESCRIPTION
## ⭐ Issue Number
> close #2

<br>

## 📌 Tasks
1. 시큐리티 설정 (customUserDetails, CustomUserDetailService)
2. 관리자 로그인, 회원 가입 로직

<br>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자 로그인을 위한 `/auth/admin/login` 및 회원가입을 위한 `/auth/admin/sign-up` 엔드포인트가 추가되었습니다.
  * 관리자 로그인 및 회원가입 시 액세스 토큰이 반환됩니다.
  * 관리자 인증 관련 요청에 대해 인증 없이 접근이 허용됩니다.
  * 사용자 조회 기능이 사용자명과 ID로 확장되었습니다.

* **버그 수정**
  * 강사 등록 응답의 패키지 위치가 올바르게 수정되었습니다.
  * 강사 등록 시 HTTP 201(Created) 상태 코드가 명확하게 반환됩니다.

* **기타**
  * 데이터베이스(MySQL) 및 JPA, JWT 관련 설정이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->