### PR TITLE
Add admin login and signup API with JWT authentication and MySQL config

### DIFF
--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/config/SecurityConfig.kt
@@ -33,7 +33,9 @@ class SecurityConfig(
             .authorizeHttpRequests { requests ->
                 requests
                     .requestMatchers(
-                        "/swagger-ui/**"
+                        "/swagger-ui/**",
+                        "/auth/admin/login",
+                        "/auth/admin/sign-up"
                     ).permitAll()
                     .anyRequest().authenticated()
             }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetails.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetails.kt
@@ -1,28 +1,24 @@
 package com.soomsoom.backend.adapter.`in`.security.service
 
-import com.soomsoom.backend.application.port.out.user.UserPort
-import org.springframework.security.core.userdetails.User
+import com.soomsoom.backend.domain.user.model.Account
+import com.soomsoom.backend.domain.user.model.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
-import org.springframework.security.core.userdetails.UserDetailsService
-import org.springframework.security.core.userdetails.UsernameNotFoundException
-import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
-@Service
 class CustomUserDetails(
-    private val userPort: UserPort,
-) : UserDetailsService {
-
-    @Transactional(readOnly = true)
-    override fun loadUserByUsername(username: String): UserDetails {
-        val user = (
-            userPort.findById(username.toLong())
-                ?: throw UsernameNotFoundException("해당 유저를 찾을 수 없습니다: $username")
-            )
-
-        return User.builder()
-            .username(user.id.toString())
-            .roles(user.role.name)
-            .build()
+    private val user: User
+) : UserDetails {
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
+        return mutableListOf(SimpleGrantedAuthority(user.role.name))
     }
+
+    override fun getPassword(): String {
+        return (user.account as Account.IdPassword).password
+    }
+
+    override fun getUsername(): String {
+        return (user.account as Account.IdPassword).username
+    }
+
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetails.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetails.kt
@@ -7,7 +7,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
 class CustomUserDetails(
-    private val user: User
+    private val user: User,
 ) : UserDetails {
     override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
         return mutableListOf(SimpleGrantedAuthority(user.role.name))
@@ -20,5 +20,4 @@ class CustomUserDetails(
     override fun getUsername(): String {
         return (user.account as Account.IdPassword).username
     }
-
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetailsService.kt
@@ -1,0 +1,24 @@
+package com.soomsoom.backend.adapter.`in`.security.service
+
+import com.soomsoom.backend.application.port.out.user.UserPort
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CustomUserDetailsService(
+    private val userPort: UserPort,
+) : UserDetailsService {
+
+    @Transactional(readOnly = true)
+    override fun loadUserByUsername(username: String): UserDetails {
+        val user = (
+            userPort.findByUsername(username)
+                ?: throw UsernameNotFoundException("해당 유저를 찾을 수 없습니다: $username")
+            )
+
+        return CustomUserDetails(user);
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetailsService.kt
@@ -19,6 +19,6 @@ class CustomUserDetailsService(
                 ?: throw UsernameNotFoundException("해당 유저를 찾을 수 없습니다: $username")
             )
 
-        return CustomUserDetails(user);
+        return CustomUserDetails(user)
     }
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/AuthController.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/AuthController.kt
@@ -24,7 +24,7 @@ class AuthController(
     @ResponseStatus(HttpStatus.OK)
     fun adminLogin(
         @RequestBody request: AdminLoginRequest,
-    ) : TokenInfo {
+    ): TokenInfo {
         println("controller")
         return adminLoginUseCase.adminLogin(request.toCommand())
     }
@@ -33,7 +33,7 @@ class AuthController(
     @ResponseStatus(HttpStatus.CREATED)
     fun adminSignUp(
         @RequestBody request: AdminSignUpRequest,
-    ) : TokenInfo {
+    ): TokenInfo {
         return adminSignUpUserCase.adminSignUp(request.toCommand())
     }
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/AuthController.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/AuthController.kt
@@ -1,0 +1,39 @@
+package com.soomsoom.backend.adapter.`in`.web.api.auth
+
+import com.soomsoom.backend.adapter.`in`.web.api.auth.request.AdminLoginRequest
+import com.soomsoom.backend.adapter.`in`.web.api.auth.request.AdminSignUpRequest
+import com.soomsoom.backend.adapter.`in`.web.api.auth.request.toCommand
+import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
+import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminLoginUseCase
+import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminSignUpUseCase
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth")
+class AuthController(
+    private val adminLoginUseCase: AdminLoginUseCase,
+    private val adminSignUpUserCase: AdminSignUpUseCase,
+) {
+
+    @PostMapping("/admin/login")
+    @ResponseStatus(HttpStatus.OK)
+    fun adminLogin(
+        @RequestBody request: AdminLoginRequest,
+    ) : TokenInfo {
+        println("controller")
+        return adminLoginUseCase.adminLogin(request.toCommand())
+    }
+
+    @PostMapping("/admin/sign-up")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun adminSignUp(
+        @RequestBody request: AdminSignUpRequest,
+    ) : TokenInfo {
+        return adminSignUpUserCase.adminSignUp(request.toCommand())
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminLoginRequest.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminLoginRequest.kt
@@ -9,5 +9,5 @@ data class AdminLoginRequest(
 
 fun AdminLoginRequest.toCommand() = AdminLoginCommand(
     username,
-    password,
+    password
 )

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminLoginRequest.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminLoginRequest.kt
@@ -1,0 +1,13 @@
+package com.soomsoom.backend.adapter.`in`.web.api.auth.request
+
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminLoginCommand
+
+data class AdminLoginRequest(
+    val username: String,
+    val password: String,
+)
+
+fun AdminLoginRequest.toCommand() = AdminLoginCommand(
+    username,
+    password,
+)

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminSignUpRequest.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/auth/request/AdminSignUpRequest.kt
@@ -1,0 +1,10 @@
+package com.soomsoom.backend.adapter.`in`.web.api.auth.request
+
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminSignUpCommand
+
+data class AdminSignUpRequest(
+    val username: String,
+    val password: String,
+)
+
+fun AdminSignUpRequest.toCommand() = AdminSignUpCommand(username, password)

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/instructor/InstructorController.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/instructor/InstructorController.kt
@@ -1,11 +1,13 @@
 package com.soomsoom.backend.adapter.`in`.web.api.instructor
 
 import com.soomsoom.backend.adapter.`in`.web.api.instructor.request.RegisterInstructorRequest
-import com.soomsoom.backend.adapter.`in`.web.api.instructor.request.RegisterInstructorResponse
 import com.soomsoom.backend.adapter.`in`.web.api.instructor.request.toCommand
+import com.soomsoom.backend.adapter.`in`.web.api.instructor.response.RegisterInstructorResponse
 import com.soomsoom.backend.application.port.`in`.instructor.usecase.RegisterInstructorUseCase
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -14,6 +16,7 @@ class InstructorController(
 ) {
 
     @PostMapping("/instructors")
+    @ResponseStatus(HttpStatus.CREATED)
     fun register(
         @RequestBody request: RegisterInstructorRequest,
     ): RegisterInstructorResponse {

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/instructor/response/RegisterInstructorResponse.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/instructor/response/RegisterInstructorResponse.kt
@@ -1,4 +1,4 @@
-package com.soomsoom.backend.adapter.`in`.web.api.instructor.request
+package com.soomsoom.backend.adapter.`in`.web.api.instructor.response
 
 import com.soomsoom.backend.domain.instructor.model.Instructor
 

--- a/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/user/UserPersistenceAdapter.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/user/UserPersistenceAdapter.kt
@@ -19,4 +19,14 @@ class UserPersistenceAdapter(
     override fun findByDeviceId(deviceId: String): User? {
         return userJpaRepository.findByDeviceId(deviceId)?.toDomain()
     }
+
+    override fun findById(userId: Long): User? {
+        return userJpaRepository.findById(userId)
+            .map { it.toDomain() }
+            .orElse(null)
+    }
+
+    override fun findByUsername(username: String): User? {
+        return userJpaRepository.findByUsername(username)?.toDomain()
+    }
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/user/repository/jpa/UserJpaRepository.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/user/repository/jpa/UserJpaRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserJpaRepository : JpaRepository<UserJpaEntity, Long> {
     fun findByDeviceId(deviceId: String): UserJpaEntity?
+    fun findByUsername(username: String): UserJpaEntity?
 }

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/TokenInfo.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/TokenInfo.kt
@@ -1,0 +1,5 @@
+package com.soomsoom.backend.application.port.`in`.auth
+
+data class TokenInfo(
+    val accessToken: String,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/command/AdminLoginCommand.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/command/AdminLoginCommand.kt
@@ -1,0 +1,6 @@
+package com.soomsoom.backend.application.port.`in`.auth.command
+
+data class AdminLoginCommand(
+    val username: String,
+    val password: String,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/command/AdminSignUpCommand.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/command/AdminSignUpCommand.kt
@@ -1,0 +1,6 @@
+package com.soomsoom.backend.application.port.`in`.auth.command
+
+data class AdminSignUpCommand(
+    val username: String,
+    val password: String,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/usecase/AdminLoginUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/usecase/AdminLoginUseCase.kt
@@ -1,0 +1,8 @@
+package com.soomsoom.backend.application.port.`in`.auth.usecase
+
+import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminLoginCommand
+
+interface AdminLoginUseCase {
+    fun adminLogin(command: AdminLoginCommand): TokenInfo
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/usecase/AdminSignUpUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/auth/usecase/AdminSignUpUseCase.kt
@@ -1,0 +1,9 @@
+package com.soomsoom.backend.application.port.`in`.auth.usecase
+
+import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminSignUpCommand
+
+interface AdminSignUpUseCase {
+
+    fun adminSignUp(command: AdminSignUpCommand): TokenInfo
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/out/user/UserPort.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/out/user/UserPort.kt
@@ -9,4 +9,6 @@ interface UserPort {
     fun findByDeviceId(deviceId: String): User?
 
     fun findById(userId: Long): User?
+
+    fun findByUsername(username: String): User?
 }

--- a/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminLoginService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminLoginService.kt
@@ -1,0 +1,44 @@
+package com.soomsoom.backend.application.service.auth
+
+import com.soomsoom.backend.adapter.`in`.security.provider.JwtTokenProvider
+import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminLoginCommand
+import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminLoginUseCase
+import com.soomsoom.backend.application.port.out.user.UserPort
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class AdminLoginService(
+    private val userPort: UserPort,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val authenticationManagerBuilder: AuthenticationManagerBuilder,
+) : AdminLoginUseCase {
+    override fun adminLogin(command: AdminLoginCommand): TokenInfo {
+
+
+        val authenticationToken = UsernamePasswordAuthenticationToken(command.username, command.password)
+        println(command.password)
+        val authResult = authenticationManagerBuilder.`object`.authenticate(authenticationToken)
+        println(123123123123123)
+
+        return userPort.findByUsername(authResult.name)
+            ?.let { user ->
+                UsernamePasswordAuthenticationToken(
+                    User(user.id.toString(), "", authResult.authorities),
+                    "",
+                    authResult.authorities
+                )
+            }
+            ?.let ( jwtTokenProvider::generateToken )
+            ?.let { TokenInfo(it) }
+            ?:throw UsernameNotFoundException("User not found with username: ${authResult.name}")
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminLoginService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminLoginService.kt
@@ -5,12 +5,10 @@ import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
 import com.soomsoom.backend.application.port.`in`.auth.command.AdminLoginCommand
 import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminLoginUseCase
 import com.soomsoom.backend.application.port.out.user.UserPort
-import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UsernameNotFoundException
-import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -22,8 +20,6 @@ class AdminLoginService(
     private val authenticationManagerBuilder: AuthenticationManagerBuilder,
 ) : AdminLoginUseCase {
     override fun adminLogin(command: AdminLoginCommand): TokenInfo {
-
-
         val authenticationToken = UsernamePasswordAuthenticationToken(command.username, command.password)
         println(command.password)
         val authResult = authenticationManagerBuilder.`object`.authenticate(authenticationToken)
@@ -37,8 +33,8 @@ class AdminLoginService(
                     authResult.authorities
                 )
             }
-            ?.let ( jwtTokenProvider::generateToken )
+            ?.let(jwtTokenProvider::generateToken)
             ?.let { TokenInfo(it) }
-            ?:throw UsernameNotFoundException("User not found with username: ${authResult.name}")
+            ?: throw UsernameNotFoundException("User not found with username: ${authResult.name}")
     }
 }

--- a/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminSignUpService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminSignUpService.kt
@@ -16,7 +16,7 @@ class AdminSignUpService(
     private val userPort: UserPort,
     private val passwordEncoder: PasswordEncoder,
     private val jwtTokenProvider: JwtTokenProvider,
-) : AdminSignUpUseCase{
+) : AdminSignUpUseCase {
     override fun adminSignUp(command: AdminSignUpCommand): TokenInfo {
         userPort.findByUsername(command.username)?.let {
             throw IllegalStateException("이미 존재하는 계정 이름")
@@ -25,7 +25,8 @@ class AdminSignUpService(
         return passwordEncoder.encode(command.password)
             .let { encodedPassword ->
                 println(encodedPassword)
-                User.createAdmin(command.username, encodedPassword) }
+                User.createAdmin(command.username, encodedPassword)
+            }
             .let(userPort::save)
             .let { savedUser ->
                 val authorities = listOf(SimpleGrantedAuthority(savedUser.role.name))

--- a/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminSignUpService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminSignUpService.kt
@@ -1,0 +1,42 @@
+package com.soomsoom.backend.application.service.auth
+
+import com.soomsoom.backend.adapter.`in`.security.provider.JwtTokenProvider
+import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
+import com.soomsoom.backend.application.port.`in`.auth.command.AdminSignUpCommand
+import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminSignUpUseCase
+import com.soomsoom.backend.application.port.out.user.UserPort
+import com.soomsoom.backend.domain.user.model.User
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+
+@Service
+class AdminSignUpService(
+    private val userPort: UserPort,
+    private val passwordEncoder: PasswordEncoder,
+    private val jwtTokenProvider: JwtTokenProvider,
+) : AdminSignUpUseCase{
+    override fun adminSignUp(command: AdminSignUpCommand): TokenInfo {
+        userPort.findByUsername(command.username)?.let {
+            throw IllegalStateException("이미 존재하는 계정 이름")
+        }
+
+        return passwordEncoder.encode(command.password)
+            .let { encodedPassword ->
+                println(encodedPassword)
+                User.createAdmin(command.username, encodedPassword) }
+            .let(userPort::save)
+            .let { savedUser ->
+                val authorities = listOf(SimpleGrantedAuthority(savedUser.role.name))
+                val principal = org.springframework.security.core.userdetails.User(
+                    savedUser.id.toString(),
+                    "",
+                    authorities
+                )
+                UsernamePasswordAuthenticationToken(principal, "", authorities)
+            }
+            .let(jwtTokenProvider::generateToken)
+            .let { TokenInfo(it) }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,14 @@
 spring.application.name=backend
+
+spring.datasource.url=jdbc:mysql://localhost:3306/soomsoom?useSSL=false&serverTimezone=Asia/Seoul
+spring.datasource.username=root
+spring.datasource.password=root
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sqltrue
 jwt.secret= aweijfiweajflkjkljf32iojfoijslkfjiefjawefaw434
 jwt.access.expiration=3600000
+
+
+


### PR DESCRIPTION
## ⭐ Issue Number
> close #2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자 계정의 로그인 및 회원가입 API 엔드포인트(/auth/admin/login, /auth/admin/sign-up)가 추가되었습니다.
  * 관리자 로그인 및 회원가입 시 토큰이 발급됩니다.
  * 관리자 인증을 위한 요청 본문 형식이 추가되었습니다.

* **보안**
  * 관리자 로그인 및 회원가입 엔드포인트가 인증 없이 접근 가능하도록 변경되었습니다.

* **개선 및 버그 수정**
  * 강사 등록 시 정상적으로 201 Created 응답을 반환하도록 수정되었습니다.

* **설정**
  * MySQL 데이터베이스 및 JPA 관련 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->