### PR TITLE
감정 기록(일기) 기능 전 계층 추가 및 인증 체계 정비(JWT userId, CustomUserDetails)

### DIFF
--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetails.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetails.kt
@@ -7,19 +7,26 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
 class CustomUserDetails(
-    private val user: User,
+    val id: Long,
+    private val username: String,
+    private val password: String,
+    private val authorities: MutableCollection<out GrantedAuthority>,
 ) : UserDetails {
-    override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
-        return mutableListOf(SimpleGrantedAuthority(user.role.name))
-    }
 
-    override fun getPassword(): String {
-        return (user.account as Account.IdPassword).password
-    }
+    // 로그인 시 사용될 생성자
+    constructor(user: User) : this(
+        id = user.id!!,
+        username = (user.account as Account.IdPassword).username,
+        password = (user.account as Account.IdPassword).password,
+        authorities = mutableListOf(SimpleGrantedAuthority(user.role.name))
+    )
 
-    override fun getUsername(): String {
-        return (user.account as Account.IdPassword).username
-    }
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority> = authorities
+    override fun getPassword(): String = password
+    override fun getUsername(): String = username
 
-    val id = user.id
+    override fun isAccountNonExpired(): Boolean = true
+    override fun isAccountNonLocked(): Boolean = true
+    override fun isCredentialsNonExpired(): Boolean = true
+    override fun isEnabled(): Boolean = true
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/service/CustomUserDetailsService.kt
@@ -3,6 +3,7 @@ package com.soomsoom.backend.adapter.`in`.security.service
 import com.soomsoom.backend.application.port.out.user.UserPort
 import com.soomsoom.backend.common.exception.SoomSoomException
 import com.soomsoom.backend.domain.user.UserErrorCode
+import com.soomsoom.backend.domain.user.model.Account
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.stereotype.Service
@@ -15,11 +16,16 @@ class CustomUserDetailsService(
 
     @Transactional(readOnly = true)
     override fun loadUserByUsername(username: String): UserDetails {
-        val user = (
-            userPort.findByUsername(username)
-                ?: throw SoomSoomException(UserErrorCode.USERNAME_OR_PASSWORD_MISMATCH)
-            )
+        val user = userPort.findByUsername(username)
+            ?: throw SoomSoomException(UserErrorCode.USERNAME_OR_PASSWORD_MISMATCH)
 
+        // ✨ 수정: user.account가 IdPassword 타입인지 확인하여 ClassCastException 방지
+        if (user.account !is Account.IdPassword) {
+            // 아이디/비밀번호 계정이 아니므로 인증 처리 불가
+            throw SoomSoomException(UserErrorCode.USERNAME_OR_PASSWORD_MISMATCH)
+        }
+
+        // 이 시점부터 user는 IdPassword 계정을 가진 것이 보장됨
         return CustomUserDetails(user)
     }
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/DiaryController.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/DiaryController.kt
@@ -1,0 +1,139 @@
+package com.soomsoom.backend.adapter.`in`.web.api.diary
+
+import com.soomsoom.backend.adapter.`in`.security.service.CustomUserDetails
+import com.soomsoom.backend.adapter.`in`.web.api.diary.request.GetDailyDiaryRecordRequest
+import com.soomsoom.backend.adapter.`in`.web.api.diary.request.GetMonthlyDiaryStatsRequest
+import com.soomsoom.backend.adapter.`in`.web.api.diary.request.RegisterDiaryRequest
+import com.soomsoom.backend.adapter.`in`.web.api.diary.request.SearchDiariesRequest
+import com.soomsoom.backend.adapter.`in`.web.api.diary.request.UpdateDiaryRequest
+import com.soomsoom.backend.adapter.`in`.web.api.diary.request.toCommand
+import com.soomsoom.backend.adapter.`in`.web.api.diary.request.toCriteria
+import com.soomsoom.backend.application.port.`in`.diary.command.DeleteDiaryCommand
+import com.soomsoom.backend.application.port.`in`.diary.dto.FindDiaryResult
+import com.soomsoom.backend.application.port.`in`.diary.dto.GetDailyDiaryRecordResult
+import com.soomsoom.backend.application.port.`in`.diary.dto.GetMonthlyDiaryStatsResult
+import com.soomsoom.backend.application.port.`in`.diary.dto.RegisterDiaryResult
+import com.soomsoom.backend.application.port.`in`.diary.usecase.command.DeleteDiaryUseCase
+import com.soomsoom.backend.application.port.`in`.diary.usecase.command.RegisterDiaryUseCase
+import com.soomsoom.backend.application.port.`in`.diary.usecase.command.UpdateDiaryUseCase
+import com.soomsoom.backend.application.port.`in`.diary.usecase.query.FindDiaryByIdUseCase
+import com.soomsoom.backend.application.port.`in`.diary.usecase.query.GetDailyDiaryRecordUseCase
+import com.soomsoom.backend.application.port.`in`.diary.usecase.query.GetMonthlyDiaryStatsUseCase
+import com.soomsoom.backend.application.port.`in`.diary.usecase.query.SearchDiariesUseCase
+import com.soomsoom.backend.domain.common.DeletionStatus
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class DiaryController(
+    private val registerDiaryUseCase: RegisterDiaryUseCase,
+    private val findDiaryByIdUseCase: FindDiaryByIdUseCase,
+    private val searchDiariesUseCase: SearchDiariesUseCase,
+    private val updateDiaryUseCase: UpdateDiaryUseCase,
+    private val deleteDiaryUseCase: DeleteDiaryUseCase,
+    private val findMonthlyDiaryStatsUseCase: GetMonthlyDiaryStatsUseCase,
+    private val getDailyDiaryRecordUseCase: GetDailyDiaryRecordUseCase,
+) {
+
+    @PostMapping("/diaries")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun register(
+        @AuthenticationPrincipal userDetails: CustomUserDetails,
+        @Valid @RequestBody
+        request: RegisterDiaryRequest,
+    ): RegisterDiaryResult {
+        return registerDiaryUseCase.register(request.toCommand(userDetails.id))
+    }
+
+    /**
+     * 감정 일기 단 건 조회
+     */
+    @GetMapping("/diaries/{diaryId}")
+    @ResponseStatus(HttpStatus.OK)
+    fun findById(
+        @PathVariable diaryId: Long,
+        @RequestParam(required = false) deletionStatus: DeletionStatus?,
+    ): FindDiaryResult {
+        return findDiaryByIdUseCase.findById(diaryId, deletionStatus ?: DeletionStatus.ACTIVE)
+    }
+
+    /**
+     * 감정 일기 페이징 조회
+     */
+    @GetMapping("/diaries")
+    @ResponseStatus(HttpStatus.OK)
+    fun search(
+        @AuthenticationPrincipal userDetails: CustomUserDetails,
+        @Valid @ModelAttribute
+        request: SearchDiariesRequest,
+        pageable: Pageable,
+    ): Page<FindDiaryResult> {
+        return searchDiariesUseCase.search(request.toCriteria(userDetails.id), pageable)
+    }
+
+    /**
+     * 월 별 감정 통계
+     */
+
+    @GetMapping("/diaries/stats")
+    @ResponseStatus(HttpStatus.OK)
+    fun getMonthlyStats(
+        @AuthenticationPrincipal userDetails: CustomUserDetails,
+        @Valid @ModelAttribute
+        request: GetMonthlyDiaryStatsRequest,
+    ): GetMonthlyDiaryStatsResult {
+        return findMonthlyDiaryStatsUseCase.findStats(request.toCriteria(userDetails.id))
+    }
+
+    /**
+     * 요일별 감정 기록 조회
+     */
+    @GetMapping("/diaries/daily")
+    @ResponseStatus(HttpStatus.OK)
+    fun getDailyDiaryRecord(
+        @AuthenticationPrincipal userDetails: CustomUserDetails,
+        @Valid @ModelAttribute
+        request: GetDailyDiaryRecordRequest,
+    ): List<GetDailyDiaryRecordResult> {
+        return getDailyDiaryRecordUseCase.getDailyDiaryRecord(request.toCriteria(userDetails.id))
+    }
+
+    /**
+     * 감정 일기 수정
+     */
+    @PatchMapping("/diaries/{diaryId}")
+    @ResponseStatus(HttpStatus.OK)
+    fun update(
+        @PathVariable diaryId: Long,
+        @Valid @RequestBody
+        request: UpdateDiaryRequest,
+    ): FindDiaryResult {
+        return updateDiaryUseCase.update(request.toCommand(diaryId))
+    }
+
+    /**
+     * 감정 일기 삭제 (Soft Delete)
+     */
+    @DeleteMapping("/diaries/{diaryId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(
+        @AuthenticationPrincipal userDetails: CustomUserDetails,
+        @PathVariable diaryId: Long,
+    ) {
+        val command = DeleteDiaryCommand(diaryId = diaryId, principalId = userDetails.id)
+        deleteDiaryUseCase.softDelete(command)
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/config/DiaryConfigurer.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/config/DiaryConfigurer.kt
@@ -10,6 +10,6 @@ class DiaryConfigurer : DomainSecurityConfigurer {
     override fun configure(
         authorize: AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry,
     ) {
-        authorize.requestMatchers("/api/v1/diaries/**").authenticated()
+        authorize.requestMatchers("/diaries/**").authenticated()
     }
 }

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/config/DiaryConfigurer.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/config/DiaryConfigurer.kt
@@ -1,0 +1,15 @@
+package com.soomsoom.backend.adapter.`in`.web.api.diary.config
+
+import com.soomsoom.backend.adapter.`in`.security.config.DomainSecurityConfigurer
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer
+import org.springframework.stereotype.Component
+
+@Component
+class DiaryConfigurer : DomainSecurityConfigurer {
+    override fun configure(
+        authorize: AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry,
+    ) {
+        authorize.requestMatchers("/api/v1/diaries/**").authenticated()
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/request/GetDailyDiaryRecordRequest.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/request/GetDailyDiaryRecordRequest.kt
@@ -1,0 +1,24 @@
+package com.soomsoom.backend.adapter.`in`.web.api.diary.request
+
+import com.soomsoom.backend.application.port.`in`.diary.query.GetDailyDiaryRecordCriteria
+import com.soomsoom.backend.domain.common.DeletionStatus
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class GetDailyDiaryRecordRequest(
+    val userId: Long?,
+    @field:NotNull(message = "조회 시작일은 필수입니다.")
+    val from: LocalDate?,
+    @field:NotNull(message = "조회 종료일은 필수입니다.")
+    val to: LocalDate?,
+    val deletionStatus: DeletionStatus?,
+)
+
+fun GetDailyDiaryRecordRequest.toCriteria(principalId: Long): GetDailyDiaryRecordCriteria {
+    return GetDailyDiaryRecordCriteria(
+        userId = this.userId ?: principalId, // 요청 받은 userId가 없으면 로그인한 사용자 ID 사용
+        from = this.from!!,
+        to = this.to!!,
+        deletionStatus = this.deletionStatus ?: DeletionStatus.ACTIVE
+    )
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/request/GetMonthlyDiaryStatsRequest.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/request/GetMonthlyDiaryStatsRequest.kt
@@ -1,0 +1,23 @@
+package com.soomsoom.backend.adapter.`in`.web.api.diary.request
+
+import com.soomsoom.backend.application.port.`in`.diary.query.GetMonthlyDiaryStatsCriteria
+import com.soomsoom.backend.domain.common.DeletionStatus
+import jakarta.validation.constraints.NotNull
+import java.time.YearMonth
+
+data class GetMonthlyDiaryStatsRequest(
+    val userId: Long?,
+    @field:NotNull(message = "조회 년도(year)는 필수입니다.")
+    val year: Int?,
+    @field:NotNull(message = "조회 월(month)은 필수입니다.")
+    val month: Int?,
+    val deletionStatus: DeletionStatus?,
+)
+
+fun GetMonthlyDiaryStatsRequest.toCriteria(principalId: Long): GetMonthlyDiaryStatsCriteria {
+    return GetMonthlyDiaryStatsCriteria(
+        userId = this.userId ?: principalId,
+        yearMonth = YearMonth.of(this.year!!, this.month!!),
+        deletionStatus = this.deletionStatus ?: DeletionStatus.ACTIVE
+    )
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/request/RegisterDiaryRequest.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/request/RegisterDiaryRequest.kt
@@ -1,0 +1,23 @@
+package com.soomsoom.backend.adapter.`in`.web.api.diary.request
+
+import com.soomsoom.backend.application.port.`in`.diary.command.RegisterDiaryCommand
+import com.soomsoom.backend.domain.diary.model.Emotion
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class RegisterDiaryRequest(
+    @field:NotNull(message = "감정은 필수 항목입니다.")
+    val emotion: Emotion?,
+    val memo: String?,
+    @field:NotNull(message = "날짜는 필수 항목입니다.")
+    val date: LocalDate?,
+)
+
+fun RegisterDiaryRequest.toCommand(userId: Long): RegisterDiaryCommand {
+    return RegisterDiaryCommand(
+        userId = userId,
+        emotion = this.emotion!!,
+        memo = this.memo,
+        date = this.date!!
+    )
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/request/SearchDiariesRequest.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/request/SearchDiariesRequest.kt
@@ -1,0 +1,24 @@
+package com.soomsoom.backend.adapter.`in`.web.api.diary.request
+
+import com.soomsoom.backend.application.port.`in`.diary.query.SearchDiariesCriteria
+import com.soomsoom.backend.domain.common.DeletionStatus
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class SearchDiariesRequest(
+    val userId: Long?,
+    @field:NotNull(message = "조회 시작일은 필수입니다.")
+    val from: LocalDate?,
+    @field:NotNull(message = "조회 종료일은 필수입니다.")
+    val to: LocalDate?,
+    val deletionStatus: DeletionStatus?,
+)
+
+fun SearchDiariesRequest.toCriteria(principalId: Long): SearchDiariesCriteria {
+    return SearchDiariesCriteria(
+        userId = this.userId ?: principalId, // 요청 받은 userId가 없으면 로그인한 사용자 ID 사용
+        from = this.from!!,
+        to = this.to!!,
+        deletionStatus = this.deletionStatus ?: DeletionStatus.ACTIVE
+    )
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/request/UpdateDiaryRequest.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/diary/request/UpdateDiaryRequest.kt
@@ -1,0 +1,19 @@
+package com.soomsoom.backend.adapter.`in`.web.api.diary.request
+
+import com.soomsoom.backend.application.port.`in`.diary.command.UpdateDiaryCommand
+import com.soomsoom.backend.domain.diary.model.Emotion
+import jakarta.validation.constraints.NotNull
+
+data class UpdateDiaryRequest(
+    @field:NotNull(message = "감정은 필수 항목입니다.")
+    val emotion: Emotion?,
+    val memo: String?,
+)
+
+fun UpdateDiaryRequest.toCommand(diaryId: Long): UpdateDiaryCommand {
+    return UpdateDiaryCommand(
+        diaryId = diaryId,
+        emotion = this.emotion!!,
+        memo = this.memo
+    )
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/activity/repository/jpa/ActivityQueryDslRepository.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/activity/repository/jpa/ActivityQueryDslRepository.kt
@@ -4,9 +4,11 @@ import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.soomsoom.backend.adapter.out.persistence.activity.repository.jpa.dto.ActivityWithInstructorsDto
 import com.soomsoom.backend.adapter.out.persistence.activity.repository.jpa.dto.QActivityWithInstructorsDto
+import com.soomsoom.backend.adapter.out.persistence.activity.repository.jpa.entity.ActivityJpaEntity
 import com.soomsoom.backend.adapter.out.persistence.activity.repository.jpa.entity.QActivityJpaEntity.activityJpaEntity
 import com.soomsoom.backend.adapter.out.persistence.instructor.repository.jpa.entity.QInstructorJpaEntity
 import com.soomsoom.backend.application.port.`in`.activity.query.SearchActivitiesCriteria
+import com.soomsoom.backend.common.utils.QueryDslSortUtil
 import com.soomsoom.backend.domain.common.DeletionStatus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -59,7 +61,7 @@ class ActivityQueryDslRepository(
             )
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
-            .orderBy(activityJpaEntity.createdAt.desc())
+            .orderBy(*QueryDslSortUtil.toOrderSpecifiers(pageable.sort, ActivityJpaEntity::class.java).toTypedArray())
             .fetch()
 
         val countQuery = queryFactory

--- a/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/diary/DiaryMapper.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/diary/DiaryMapper.kt
@@ -1,0 +1,28 @@
+package com.soomsoom.backend.adapter.out.persistence.diary
+
+import com.soomsoom.backend.adapter.out.persistence.diary.repository.jpa.entity.DiaryJpaEntity
+import com.soomsoom.backend.domain.diary.model.Diary
+
+fun DiaryJpaEntity.toDomain(): Diary {
+    return Diary(
+        id = this.id,
+        userId = this.userId,
+        emotion = this.emotion,
+        memo = this.memo,
+        recordDate = this.recordDate,
+        createdAt = this.createdAt,
+        modifiedAt = this.modifiedAt,
+        deletedAt = this.deletedAt
+    )
+}
+
+// Domain Model -> JPA Entity
+fun Diary.toEntity(): DiaryJpaEntity {
+    return DiaryJpaEntity(
+        id = this.id ?: 0,
+        userId = this.userId,
+        emotion = this.emotion,
+        memo = this.memo,
+        recordDate = this.recordDate
+    )
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/diary/repository/DiaryPersistenceAdapter.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/diary/repository/DiaryPersistenceAdapter.kt
@@ -1,0 +1,78 @@
+package com.soomsoom.backend.adapter.out.persistence.diary.repository
+
+import com.soomsoom.backend.adapter.out.persistence.diary.repository.jpa.DiaryJpaRepository
+import com.soomsoom.backend.adapter.out.persistence.diary.repository.jpa.DiaryQueryDslRepository
+import com.soomsoom.backend.adapter.out.persistence.diary.toDomain
+import com.soomsoom.backend.adapter.out.persistence.diary.toEntity
+import com.soomsoom.backend.application.port.`in`.diary.query.GetDailyDiaryRecordCriteria
+import com.soomsoom.backend.application.port.`in`.diary.query.GetMonthlyDiaryStatsCriteria
+import com.soomsoom.backend.application.port.`in`.diary.query.SearchDiariesCriteria
+import com.soomsoom.backend.application.port.out.diary.DiaryPort
+import com.soomsoom.backend.application.port.out.diary.dto.DailyDiaryRecordAdapterDto
+import com.soomsoom.backend.application.port.out.diary.dto.EmotionCount
+import com.soomsoom.backend.common.exception.SoomSoomException
+import com.soomsoom.backend.domain.common.DeletionStatus
+import com.soomsoom.backend.domain.diary.DiaryErrorCode
+import com.soomsoom.backend.domain.diary.model.Diary
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+class DiaryPersistenceAdapter(
+    private val diaryJpaRepository: DiaryJpaRepository,
+    private val diaryQueryDslRepository: DiaryQueryDslRepository,
+) : DiaryPort {
+    override fun save(diary: Diary): Diary {
+        val entity = diary.id?.let { id ->
+            // ID가 있으면 기존 엔티티를 찾아 업데이트
+            val existingEntity = diaryJpaRepository.findByIdOrNull(id)
+                ?: throw SoomSoomException(DiaryErrorCode.NOT_FOUND)
+
+            existingEntity.update(diary)
+            existingEntity
+        } ?: diary.toEntity() // ID가 없으면 새 엔티티를 생성
+
+        val savedEntity = diaryJpaRepository.save(entity)
+        return savedEntity.toDomain()
+    }
+
+    /**
+     * 감정 기록 단 건 조회
+     */
+    override fun findById(diaryId: Long, deletionStatus: DeletionStatus): Diary? {
+        val entity = when (deletionStatus) {
+            DeletionStatus.ACTIVE -> diaryJpaRepository.findByIdAndDeletedAtIsNull(diaryId)
+            DeletionStatus.DELETED -> diaryJpaRepository.findByIdAndDeletedAtIsNotNull(diaryId)
+            DeletionStatus.ALL -> diaryJpaRepository.findByIdOrNull(diaryId)
+        }
+        return entity?.toDomain()
+    }
+
+    override fun existsByUserIdAndRecordDate(userId: Long, date: LocalDate): Boolean {
+        return diaryJpaRepository.existsByUserIdAndRecordDate(userId, date)
+    }
+
+    /**
+     * 감정 기록 페이징 조회
+     */
+    override fun search(criteria: SearchDiariesCriteria, pageable: Pageable): Page<Diary> {
+        return diaryQueryDslRepository.search(criteria, pageable).map { it.toDomain() }
+    }
+
+    /**
+     * 월별 감정 통계
+     */
+    override fun getMonthlyEmotionCounts(criteria: GetMonthlyDiaryStatsCriteria): List<EmotionCount> {
+        return diaryQueryDslRepository.findMonthlyEmotionCounts(criteria)
+    }
+
+    /**
+     * 요일별 감정 기록
+     */
+    override fun getDailyDiaryRecords(criteria: GetDailyDiaryRecordCriteria): List<DailyDiaryRecordAdapterDto> {
+        return diaryQueryDslRepository.findDailyDiaryRecords(criteria)
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/diary/repository/jpa/DiaryJpaRepository.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/diary/repository/jpa/DiaryJpaRepository.kt
@@ -1,0 +1,11 @@
+package com.soomsoom.backend.adapter.out.persistence.diary.repository.jpa
+
+import com.soomsoom.backend.adapter.out.persistence.diary.repository.jpa.entity.DiaryJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
+
+interface DiaryJpaRepository : JpaRepository<DiaryJpaEntity, Long> {
+    fun findByIdAndDeletedAtIsNull(id: Long): DiaryJpaEntity?
+    fun findByIdAndDeletedAtIsNotNull(id: Long): DiaryJpaEntity?
+    fun existsByUserIdAndRecordDate(userId: Long, date: LocalDate): Boolean
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/diary/repository/jpa/DiaryQueryDslRepository.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/diary/repository/jpa/DiaryQueryDslRepository.kt
@@ -1,0 +1,100 @@
+package com.soomsoom.backend.adapter.out.persistence.diary.repository.jpa
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.soomsoom.backend.adapter.out.persistence.diary.repository.jpa.entity.DiaryJpaEntity
+import com.soomsoom.backend.adapter.out.persistence.diary.repository.jpa.entity.QDiaryJpaEntity.diaryJpaEntity
+import com.soomsoom.backend.application.port.`in`.diary.query.GetDailyDiaryRecordCriteria
+import com.soomsoom.backend.application.port.`in`.diary.query.GetMonthlyDiaryStatsCriteria
+import com.soomsoom.backend.application.port.`in`.diary.query.SearchDiariesCriteria
+import com.soomsoom.backend.application.port.out.diary.dto.DailyDiaryRecordAdapterDto
+import com.soomsoom.backend.application.port.out.diary.dto.EmotionCount
+import com.soomsoom.backend.application.port.out.diary.dto.QDailyDiaryRecordAdapterDto
+import com.soomsoom.backend.application.port.out.diary.dto.QEmotionCount
+import com.soomsoom.backend.common.utils.QueryDslSortUtil
+import com.soomsoom.backend.domain.common.DeletionStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.support.PageableExecutionUtils
+import org.springframework.stereotype.Repository
+
+@Repository
+class DiaryQueryDslRepository(
+    private val queryFactory: JPAQueryFactory,
+) {
+    fun search(criteria: SearchDiariesCriteria, pageable: Pageable): Page<DiaryJpaEntity> {
+        val content = queryFactory.selectFrom(diaryJpaEntity)
+            .where(
+                diaryJpaEntity.userId.eq(criteria.userId),
+                diaryJpaEntity.recordDate.between(criteria.from, criteria.to),
+                deletionStatusEq(criteria.deletionStatus)
+            )
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .orderBy(*QueryDslSortUtil.toOrderSpecifiers(pageable.sort, DiaryJpaEntity::class.java).toTypedArray())
+            .fetch()
+
+        val countQuery = queryFactory.select(diaryJpaEntity.count())
+            .from(diaryJpaEntity)
+            .where(
+                diaryJpaEntity.userId.eq(criteria.userId),
+                diaryJpaEntity.recordDate.between(criteria.from, criteria.to),
+                deletionStatusEq(criteria.deletionStatus)
+            )
+
+        return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
+    }
+
+    /**
+     * 특정 기간 동안의 일별 요약 기록 목록을 조회
+     */
+    fun findDailyDiaryRecords(criteria: GetDailyDiaryRecordCriteria): List<DailyDiaryRecordAdapterDto> {
+        return queryFactory
+            .select(
+                QDailyDiaryRecordAdapterDto(
+                    diaryJpaEntity.id,
+                    diaryJpaEntity.emotion,
+                    diaryJpaEntity.recordDate
+                )
+            )
+            .from(diaryJpaEntity)
+            .where(
+                diaryJpaEntity.userId.eq(criteria.userId),
+                diaryJpaEntity.recordDate.between(criteria.from, criteria.to),
+                deletionStatusEq(criteria.deletionStatus)
+            )
+            .orderBy(diaryJpaEntity.recordDate.asc())
+            .fetch()
+    }
+
+    private fun deletionStatusEq(deletionStatus: DeletionStatus): BooleanExpression? {
+        return when (deletionStatus) {
+            DeletionStatus.ACTIVE -> diaryJpaEntity.deletedAt.isNull
+            DeletionStatus.DELETED -> diaryJpaEntity.deletedAt.isNotNull
+            DeletionStatus.ALL -> null
+        }
+    }
+
+    // 월 별 감정 통계
+    fun findMonthlyEmotionCounts(criteria: GetMonthlyDiaryStatsCriteria): List<EmotionCount> {
+        val yearMonth = criteria.yearMonth
+        val startDate = yearMonth.atDay(1)
+        val endDate = yearMonth.atEndOfMonth()
+
+        return queryFactory
+            .select(
+                QEmotionCount(
+                    diaryJpaEntity.emotion,
+                    diaryJpaEntity.id.count()
+                )
+            )
+            .from(diaryJpaEntity)
+            .where(
+                diaryJpaEntity.userId.eq(criteria.userId),
+                diaryJpaEntity.recordDate.between(startDate, endDate),
+                deletionStatusEq(criteria.deletionStatus)
+            )
+            .groupBy(diaryJpaEntity.emotion)
+            .fetch()
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/diary/repository/jpa/entity/DiaryJpaEntity.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/out/persistence/diary/repository/jpa/entity/DiaryJpaEntity.kt
@@ -1,0 +1,36 @@
+package com.soomsoom.backend.adapter.out.persistence.diary.repository.jpa.entity
+
+import com.soomsoom.backend.common.entity.BaseTimeEntity
+import com.soomsoom.backend.domain.diary.model.Diary
+import com.soomsoom.backend.domain.diary.model.Emotion
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+
+@Entity
+@Table(name = "diaries")
+class DiaryJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val userId: Long,
+    @Enumerated(EnumType.STRING)
+    var emotion: Emotion,
+    var memo: String?,
+    val recordDate: LocalDate,
+) : BaseTimeEntity() {
+
+    /**
+     * 감정과 메모 업데이트
+     */
+    fun update(diary: Diary) {
+        this.emotion = diary.emotion
+        this.memo = diary.memo
+        this.deletedAt = diary.deletedAt
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/command/DeleteDiaryCommand.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/command/DeleteDiaryCommand.kt
@@ -1,0 +1,6 @@
+package com.soomsoom.backend.application.port.`in`.diary.command
+
+data class DeleteDiaryCommand(
+    val diaryId: Long,
+    val principalId: Long,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/command/RegisterDiaryCommand.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/command/RegisterDiaryCommand.kt
@@ -1,0 +1,11 @@
+package com.soomsoom.backend.application.port.`in`.diary.command
+
+import com.soomsoom.backend.domain.diary.model.Emotion
+import java.time.LocalDate
+
+data class RegisterDiaryCommand(
+    val userId: Long,
+    val emotion: Emotion,
+    val memo: String?,
+    val date: LocalDate,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/command/UpdateDiaryCommand.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/command/UpdateDiaryCommand.kt
@@ -1,0 +1,9 @@
+package com.soomsoom.backend.application.port.`in`.diary.command
+
+import com.soomsoom.backend.domain.diary.model.Emotion
+
+data class UpdateDiaryCommand(
+    val diaryId: Long,
+    val emotion: Emotion,
+    val memo: String?,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/dto/FindDiaryResult.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/dto/FindDiaryResult.kt
@@ -1,0 +1,34 @@
+package com.soomsoom.backend.application.port.`in`.diary.dto
+
+import com.soomsoom.backend.common.exception.SoomSoomException
+import com.soomsoom.backend.domain.diary.DiaryErrorCode
+import com.soomsoom.backend.domain.diary.model.Diary
+import com.soomsoom.backend.domain.diary.model.Emotion
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class FindDiaryResult(
+    val diaryId: Long,
+    val userId: Long,
+    val emotion: Emotion,
+    val memo: String?,
+    val recordDate: LocalDate,
+    val createdAt: LocalDateTime,
+    val modifiedAt: LocalDateTime?,
+    val deletedAt: LocalDateTime?,
+) {
+    companion object {
+        fun from(diary: Diary): FindDiaryResult {
+            return FindDiaryResult(
+                diaryId = diary.id ?: throw SoomSoomException(DiaryErrorCode.ID_CANNOT_BE_NULL),
+                userId = diary.userId,
+                emotion = diary.emotion,
+                memo = diary.memo,
+                recordDate = diary.recordDate,
+                createdAt = diary.createdAt ?: throw SoomSoomException(DiaryErrorCode.CREATED_AT_CANNOT_BE_NULL),
+                modifiedAt = diary.modifiedAt,
+                deletedAt = diary.deletedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/dto/GetDailyDiaryRecordResult.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/dto/GetDailyDiaryRecordResult.kt
@@ -1,0 +1,21 @@
+package com.soomsoom.backend.application.port.`in`.diary.dto
+
+import com.soomsoom.backend.application.port.out.diary.dto.DailyDiaryRecordAdapterDto
+import com.soomsoom.backend.domain.diary.model.Emotion
+import java.time.LocalDate
+
+data class GetDailyDiaryRecordResult(
+    val diaryId: Long,
+    val emotion: Emotion,
+    val recordDate: LocalDate,
+) {
+    companion object {
+        fun from(summary: DailyDiaryRecordAdapterDto): GetDailyDiaryRecordResult {
+            return GetDailyDiaryRecordResult(
+                diaryId = summary.diaryId,
+                emotion = summary.emotion,
+                recordDate = summary.recordDate
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/dto/GetMonthlyDiaryStatsResult.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/dto/GetMonthlyDiaryStatsResult.kt
@@ -1,0 +1,13 @@
+package com.soomsoom.backend.application.port.`in`.diary.dto
+
+import com.soomsoom.backend.domain.diary.model.Emotion
+
+data class GetMonthlyDiaryStatsResult(
+    val stats: List<EmotionStat>,
+)
+
+data class EmotionStat(
+    val emotion: Emotion,
+    val count: Long,
+    val percentage: Int,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/dto/RegisterDiaryResult.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/dto/RegisterDiaryResult.kt
@@ -1,0 +1,37 @@
+package com.soomsoom.backend.application.port.`in`.diary.dto
+
+import com.soomsoom.backend.common.exception.SoomSoomException
+import com.soomsoom.backend.domain.diary.DiaryErrorCode
+import com.soomsoom.backend.domain.diary.model.Diary
+import com.soomsoom.backend.domain.diary.model.Emotion
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class RegisterDiaryResult(
+    val diaryId: Long,
+    val userId: Long,
+    val emotion: Emotion,
+    val memo: String?,
+    val recordDate: LocalDate,
+    val createdAt: LocalDateTime,
+    val modifiedAt: LocalDateTime?,
+    val deletedAt: LocalDateTime?,
+) {
+    companion object {
+        /**
+         * Diary 도메인 객체로 dto 생성
+         */
+        fun from(diary: Diary): RegisterDiaryResult {
+            return RegisterDiaryResult(
+                diaryId = diary.id ?: throw SoomSoomException(DiaryErrorCode.ID_CANNOT_BE_NULL),
+                userId = diary.userId,
+                emotion = diary.emotion,
+                memo = diary.memo,
+                recordDate = diary.recordDate,
+                createdAt = diary.createdAt ?: throw SoomSoomException(DiaryErrorCode.CREATED_AT_CANNOT_BE_NULL),
+                modifiedAt = diary.modifiedAt,
+                deletedAt = diary.deletedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/query/GetDailyDiaryRecordCriteria.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/query/GetDailyDiaryRecordCriteria.kt
@@ -1,0 +1,11 @@
+package com.soomsoom.backend.application.port.`in`.diary.query
+
+import com.soomsoom.backend.domain.common.DeletionStatus
+import java.time.LocalDate
+
+data class GetDailyDiaryRecordCriteria(
+    val userId: Long,
+    val from: LocalDate,
+    val to: LocalDate,
+    val deletionStatus: DeletionStatus = DeletionStatus.ACTIVE,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/query/GetMonthlyDiaryStatsCriteria.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/query/GetMonthlyDiaryStatsCriteria.kt
@@ -1,0 +1,10 @@
+package com.soomsoom.backend.application.port.`in`.diary.query
+
+import com.soomsoom.backend.domain.common.DeletionStatus
+import java.time.YearMonth
+
+data class GetMonthlyDiaryStatsCriteria(
+    val userId: Long,
+    val yearMonth: YearMonth,
+    val deletionStatus: DeletionStatus = DeletionStatus.ACTIVE,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/query/SearchDiariesCriteria.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/query/SearchDiariesCriteria.kt
@@ -1,0 +1,11 @@
+package com.soomsoom.backend.application.port.`in`.diary.query
+
+import com.soomsoom.backend.domain.common.DeletionStatus
+import java.time.LocalDate
+
+data class SearchDiariesCriteria(
+    val userId: Long,
+    val from: LocalDate,
+    val to: LocalDate,
+    val deletionStatus: DeletionStatus = DeletionStatus.ACTIVE,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/command/DeleteDiaryUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/command/DeleteDiaryUseCase.kt
@@ -1,0 +1,8 @@
+package com.soomsoom.backend.application.port.`in`.diary.usecase.command
+
+import com.soomsoom.backend.application.port.`in`.diary.command.DeleteDiaryCommand
+
+interface DeleteDiaryUseCase {
+    fun softDelete(command: DeleteDiaryCommand)
+    fun hardDelete(command: DeleteDiaryCommand)
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/command/RegisterDiaryUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/command/RegisterDiaryUseCase.kt
@@ -1,0 +1,9 @@
+package com.soomsoom.backend.application.port.`in`.diary.usecase.command
+
+import com.soomsoom.backend.application.port.`in`.diary.command.RegisterDiaryCommand
+import com.soomsoom.backend.application.port.`in`.diary.dto.RegisterDiaryResult
+
+interface RegisterDiaryUseCase {
+
+    fun register(command: RegisterDiaryCommand): RegisterDiaryResult
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/command/UpdateDiaryUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/command/UpdateDiaryUseCase.kt
@@ -1,0 +1,8 @@
+package com.soomsoom.backend.application.port.`in`.diary.usecase.command
+
+import com.soomsoom.backend.application.port.`in`.diary.command.UpdateDiaryCommand
+import com.soomsoom.backend.application.port.`in`.diary.dto.FindDiaryResult
+
+interface UpdateDiaryUseCase {
+    fun update(command: UpdateDiaryCommand): FindDiaryResult
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/query/FindDiaryByIdUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/query/FindDiaryByIdUseCase.kt
@@ -1,0 +1,8 @@
+package com.soomsoom.backend.application.port.`in`.diary.usecase.query
+
+import com.soomsoom.backend.application.port.`in`.diary.dto.FindDiaryResult
+import com.soomsoom.backend.domain.common.DeletionStatus
+
+interface FindDiaryByIdUseCase {
+    fun findById(diaryId: Long, deletionStatus: DeletionStatus = DeletionStatus.ACTIVE): FindDiaryResult
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/query/GetDailyDiaryRecordUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/query/GetDailyDiaryRecordUseCase.kt
@@ -1,0 +1,8 @@
+package com.soomsoom.backend.application.port.`in`.diary.usecase.query
+
+import com.soomsoom.backend.application.port.`in`.diary.dto.GetDailyDiaryRecordResult
+import com.soomsoom.backend.application.port.`in`.diary.query.GetDailyDiaryRecordCriteria
+
+interface GetDailyDiaryRecordUseCase {
+    fun getDailyDiaryRecord(criteria: GetDailyDiaryRecordCriteria): List<GetDailyDiaryRecordResult>
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/query/GetMonthlyDiaryStatsUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/query/GetMonthlyDiaryStatsUseCase.kt
@@ -1,0 +1,8 @@
+package com.soomsoom.backend.application.port.`in`.diary.usecase.query
+
+import com.soomsoom.backend.application.port.`in`.diary.dto.GetMonthlyDiaryStatsResult
+import com.soomsoom.backend.application.port.`in`.diary.query.GetMonthlyDiaryStatsCriteria
+
+interface GetMonthlyDiaryStatsUseCase {
+    fun findStats(criteria: GetMonthlyDiaryStatsCriteria): GetMonthlyDiaryStatsResult
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/query/SearchDiariesUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/diary/usecase/query/SearchDiariesUseCase.kt
@@ -1,0 +1,10 @@
+package com.soomsoom.backend.application.port.`in`.diary.usecase.query
+
+import com.soomsoom.backend.application.port.`in`.diary.dto.FindDiaryResult
+import com.soomsoom.backend.application.port.`in`.diary.query.SearchDiariesCriteria
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface SearchDiariesUseCase {
+    fun search(criteria: SearchDiariesCriteria, pageable: Pageable): Page<FindDiaryResult>
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/instructor/usecase/query/FindInstructorByIdUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/instructor/usecase/query/FindInstructorByIdUseCase.kt
@@ -4,5 +4,5 @@ import com.soomsoom.backend.application.port.`in`.instructor.dto.FindInstructorR
 import com.soomsoom.backend.domain.common.DeletionStatus
 
 interface FindInstructorByIdUseCase {
-    fun findById(instructorId: Long, deletionStatus: DeletionStatus): FindInstructorResult
+    fun findById(instructorId: Long, deletionStatus: DeletionStatus = DeletionStatus.ACTIVE): FindInstructorResult
 }

--- a/src/main/kotlin/com/soomsoom/backend/application/port/out/diary/DiaryPort.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/out/diary/DiaryPort.kt
@@ -1,0 +1,21 @@
+package com.soomsoom.backend.application.port.out.diary
+
+import com.soomsoom.backend.application.port.`in`.diary.query.GetDailyDiaryRecordCriteria
+import com.soomsoom.backend.application.port.`in`.diary.query.GetMonthlyDiaryStatsCriteria
+import com.soomsoom.backend.application.port.`in`.diary.query.SearchDiariesCriteria
+import com.soomsoom.backend.application.port.out.diary.dto.DailyDiaryRecordAdapterDto
+import com.soomsoom.backend.application.port.out.diary.dto.EmotionCount
+import com.soomsoom.backend.domain.common.DeletionStatus
+import com.soomsoom.backend.domain.diary.model.Diary
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import java.time.LocalDate
+
+interface DiaryPort {
+    fun save(diary: Diary): Diary
+    fun findById(diaryId: Long, deletionStatus: DeletionStatus = DeletionStatus.ACTIVE): Diary?
+    fun existsByUserIdAndRecordDate(userId: Long, date: LocalDate): Boolean
+    fun search(criteria: SearchDiariesCriteria, pageable: Pageable): Page<Diary>
+    fun getMonthlyEmotionCounts(criteria: GetMonthlyDiaryStatsCriteria): List<EmotionCount>
+    fun getDailyDiaryRecords(criteria: GetDailyDiaryRecordCriteria): List<DailyDiaryRecordAdapterDto>
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/port/out/diary/dto/DailyDiaryRecordAdapterDto.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/out/diary/dto/DailyDiaryRecordAdapterDto.kt
@@ -1,0 +1,11 @@
+package com.soomsoom.backend.application.port.out.diary.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import com.soomsoom.backend.domain.diary.model.Emotion
+import java.time.LocalDate
+
+data class DailyDiaryRecordAdapterDto @QueryProjection constructor(
+    val diaryId: Long,
+    val emotion: Emotion,
+    val recordDate: LocalDate,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/port/out/diary/dto/EmotionCount.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/out/diary/dto/EmotionCount.kt
@@ -1,0 +1,9 @@
+package com.soomsoom.backend.application.port.out.diary.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import com.soomsoom.backend.domain.diary.model.Emotion
+
+data class EmotionCount @QueryProjection constructor(
+    val emotion: Emotion,
+    val count: Long,
+)

--- a/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminLoginService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminLoginService.kt
@@ -4,19 +4,14 @@ import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
 import com.soomsoom.backend.application.port.`in`.auth.command.AdminLoginCommand
 import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminLoginUseCase
 import com.soomsoom.backend.application.port.out.auth.TokenGeneratorPort
-import com.soomsoom.backend.application.port.out.user.UserPort
-import com.soomsoom.backend.common.exception.SoomSoomException
-import com.soomsoom.backend.domain.user.UserErrorCode
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
-import org.springframework.security.core.userdetails.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 @Transactional
 class AdminLoginService(
-    private val userPort: UserPort,
     private val tokenGeneratorPort: TokenGeneratorPort,
     private val authenticationManagerBuilder: AuthenticationManagerBuilder,
 ) : AdminLoginUseCase {
@@ -24,16 +19,7 @@ class AdminLoginService(
         val authenticationToken = UsernamePasswordAuthenticationToken(command.username, command.password)
         val authResult = authenticationManagerBuilder.`object`.authenticate(authenticationToken)
 
-        return userPort.findByUsername(authResult.name)
-            ?.let { user ->
-                UsernamePasswordAuthenticationToken(
-                    User(user.id.toString(), "", authResult.authorities),
-                    "",
-                    authResult.authorities
-                )
-            }
-            ?.let(tokenGeneratorPort::generateToken)
-            ?.let { TokenInfo(it) }
-            ?: throw SoomSoomException(UserErrorCode.USERNAME_OR_PASSWORD_MISMATCH)
+        val accessToken = tokenGeneratorPort.generateToken(authResult)
+        return TokenInfo(accessToken)
     }
 }

--- a/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminSignUpService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/auth/AdminSignUpService.kt
@@ -1,5 +1,6 @@
 package com.soomsoom.backend.application.service.auth
 
+import com.soomsoom.backend.adapter.`in`.security.service.CustomUserDetails
 import com.soomsoom.backend.application.port.`in`.auth.TokenInfo
 import com.soomsoom.backend.application.port.`in`.auth.command.AdminSignUpCommand
 import com.soomsoom.backend.application.port.`in`.auth.usecase.AdminSignUpUseCase
@@ -9,7 +10,6 @@ import com.soomsoom.backend.common.exception.SoomSoomException
 import com.soomsoom.backend.domain.user.UserErrorCode
 import com.soomsoom.backend.domain.user.model.User
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -32,13 +32,8 @@ class AdminSignUpService(
             }
             .let(userPort::save)
             .let { savedUser ->
-                val authorities = listOf(SimpleGrantedAuthority(savedUser.role.name))
-                val principal = org.springframework.security.core.userdetails.User(
-                    savedUser.id.toString(),
-                    "",
-                    authorities
-                )
-                UsernamePasswordAuthenticationToken(principal, "", authorities)
+                val principal = CustomUserDetails(savedUser)
+                UsernamePasswordAuthenticationToken(principal, "", principal.authorities)
             }
             .let(tokenGeneratorPort::generateToken)
             .let { TokenInfo(it) }

--- a/src/main/kotlin/com/soomsoom/backend/application/service/diary/command/DeleteDiaryService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/diary/command/DeleteDiaryService.kt
@@ -1,0 +1,41 @@
+package com.soomsoom.backend.application.service.diary.command
+
+import com.soomsoom.backend.application.port.`in`.diary.command.DeleteDiaryCommand
+import com.soomsoom.backend.application.port.`in`.diary.usecase.command.DeleteDiaryUseCase
+import com.soomsoom.backend.application.port.out.diary.DiaryPort
+import com.soomsoom.backend.common.exception.SoomSoomException
+import com.soomsoom.backend.domain.diary.DiaryErrorCode
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class DeleteDiaryService(
+    private val diaryPort: DiaryPort,
+) : DeleteDiaryUseCase {
+    override fun softDelete(command: DeleteDiaryCommand) {
+        val diary = diaryPort.findById(command.diaryId)
+            ?.also {
+                it.delete()
+            }
+            ?: throw SoomSoomException(DiaryErrorCode.NOT_FOUND)
+
+        validateOwnership(diary.userId, command.principalId)
+        diaryPort.save(diary)
+    }
+
+    override fun hardDelete(command: DeleteDiaryCommand) {
+        TODO("Not yet implemented")
+    }
+
+    private fun validateOwnership(ownerId: Long, principalId: Long) {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val isAdmin = authentication.authorities.any { it.authority == "ROLE_ADMIN" }
+
+        // 관리자가 아니고, 일기의 소유주도 아니라면 예외 발생
+        if (!isAdmin && ownerId != principalId) {
+            throw SoomSoomException(DiaryErrorCode.FORBIDDEN)
+        }
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/service/diary/command/RegisterDiaryService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/diary/command/RegisterDiaryService.kt
@@ -1,0 +1,33 @@
+package com.soomsoom.backend.application.service.diary.command
+
+import com.soomsoom.backend.application.port.`in`.diary.command.RegisterDiaryCommand
+import com.soomsoom.backend.application.port.`in`.diary.dto.RegisterDiaryResult
+import com.soomsoom.backend.application.port.`in`.diary.usecase.command.RegisterDiaryUseCase
+import com.soomsoom.backend.application.port.out.diary.DiaryPort
+import com.soomsoom.backend.common.exception.SoomSoomException
+import com.soomsoom.backend.domain.diary.DiaryErrorCode
+import com.soomsoom.backend.domain.diary.model.Diary
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class RegisterDiaryService(
+    private val diaryPort: DiaryPort,
+) : RegisterDiaryUseCase {
+    override fun register(command: RegisterDiaryCommand): RegisterDiaryResult {
+        if (diaryPort.existsByUserIdAndRecordDate(command.userId, command.date)) {
+            // 2. 이미 일기가 존재하면, 직접 정의한 예외를 발생시킵니다.
+            throw SoomSoomException(DiaryErrorCode.DIARY_ALREADY_EXISTS)
+        }
+
+        val diary = Diary(
+            userId = command.userId,
+            emotion = command.emotion,
+            memo = command.memo,
+            recordDate = command.date
+        )
+        val savedDiary = diaryPort.save(diary)
+        return RegisterDiaryResult.from(savedDiary)
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/service/diary/command/UpdateDiaryService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/diary/command/UpdateDiaryService.kt
@@ -1,0 +1,33 @@
+package com.soomsoom.backend.application.service.diary.command
+
+import com.soomsoom.backend.application.port.`in`.diary.command.UpdateDiaryCommand
+import com.soomsoom.backend.application.port.`in`.diary.dto.FindDiaryResult
+import com.soomsoom.backend.application.port.`in`.diary.usecase.command.UpdateDiaryUseCase
+import com.soomsoom.backend.application.port.out.diary.DiaryPort
+import com.soomsoom.backend.common.exception.SoomSoomException
+import com.soomsoom.backend.domain.diary.DiaryErrorCode
+import org.springframework.security.access.prepost.PostAuthorize
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class UpdateDiaryService(
+    private val diaryPort: DiaryPort,
+) : UpdateDiaryUseCase {
+
+    @PostAuthorize("hasRole('ADMIN') or returnObject.userId == authentication.principal.id")
+    override fun update(command: UpdateDiaryCommand): FindDiaryResult {
+        val diary = diaryPort.findById(command.diaryId)
+            ?. also {
+                it.update(
+                    emotion = command.emotion,
+                    memo = command.memo
+                )
+            }
+            ?: throw SoomSoomException(DiaryErrorCode.NOT_FOUND)
+
+        val savedDiary = diaryPort.save(diary)
+        return FindDiaryResult.from(savedDiary)
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/service/diary/query/FindDiaryService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/diary/query/FindDiaryService.kt
@@ -1,0 +1,25 @@
+package com.soomsoom.backend.application.service.diary.query
+
+import com.soomsoom.backend.application.port.`in`.diary.dto.FindDiaryResult
+import com.soomsoom.backend.application.port.`in`.diary.usecase.query.FindDiaryByIdUseCase
+import com.soomsoom.backend.application.port.out.diary.DiaryPort
+import com.soomsoom.backend.common.exception.SoomSoomException
+import com.soomsoom.backend.domain.common.DeletionStatus
+import com.soomsoom.backend.domain.diary.DiaryErrorCode
+import org.springframework.security.access.prepost.PostAuthorize
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class FindDiaryService(
+    private val diaryPort: DiaryPort,
+) : FindDiaryByIdUseCase {
+
+    @PostAuthorize("hasRole('ADMIN') or (#returnObject.userId == authentication.principal.id and #deletionStatus.name() == 'ACTIVE')")
+    override fun findById(diaryId: Long, deletionStatus: DeletionStatus): FindDiaryResult {
+        val diary = diaryPort.findById(diaryId, deletionStatus)
+            ?: throw SoomSoomException(DiaryErrorCode.NOT_FOUND)
+        return FindDiaryResult.from(diary)
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/service/diary/query/GetDailyDiaryRecordService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/diary/query/GetDailyDiaryRecordService.kt
@@ -1,0 +1,22 @@
+package com.soomsoom.backend.application.service.diary.query
+
+import com.soomsoom.backend.application.port.`in`.diary.dto.GetDailyDiaryRecordResult
+import com.soomsoom.backend.application.port.`in`.diary.query.GetDailyDiaryRecordCriteria
+import com.soomsoom.backend.application.port.`in`.diary.usecase.query.GetDailyDiaryRecordUseCase
+import com.soomsoom.backend.application.port.out.diary.DiaryPort
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class GetDailyDiaryRecordService(
+    private val diaryPort: DiaryPort,
+) : GetDailyDiaryRecordUseCase {
+
+    @PreAuthorize("hasRole('ADMIN') or (#criteria.userId == authentication.principal.userId and #criteria.deletionStatus.name() == 'ACTIVE')")
+    override fun getDailyDiaryRecord(criteria: GetDailyDiaryRecordCriteria): List<GetDailyDiaryRecordResult> {
+        val dailyRecords = diaryPort.getDailyDiaryRecords(criteria)
+        return dailyRecords.map { GetDailyDiaryRecordResult.from(it) }
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/service/diary/query/GetMonthlyDiaryStatsService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/diary/query/GetMonthlyDiaryStatsService.kt
@@ -1,0 +1,58 @@
+package com.soomsoom.backend.application.service.diary.query
+
+import com.soomsoom.backend.application.port.`in`.diary.dto.EmotionStat
+import com.soomsoom.backend.application.port.`in`.diary.dto.GetMonthlyDiaryStatsResult
+import com.soomsoom.backend.application.port.`in`.diary.query.GetMonthlyDiaryStatsCriteria
+import com.soomsoom.backend.application.port.`in`.diary.usecase.query.GetMonthlyDiaryStatsUseCase
+import com.soomsoom.backend.application.port.out.diary.DiaryPort
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class GetMonthlyDiaryStatsService(
+    private val diaryPort: DiaryPort,
+) : GetMonthlyDiaryStatsUseCase {
+
+    @PreAuthorize("hasRole('ADMIN') or (#criteria.userId == authentication.principal.userId and #criteria.deletionStatus.name() == 'ACTIVE')")
+    override fun findStats(criteria: GetMonthlyDiaryStatsCriteria): GetMonthlyDiaryStatsResult {
+        val emotionCounts = diaryPort.getMonthlyEmotionCounts(criteria)
+
+        val totalCount = emotionCounts.sumOf { it.count }
+
+        if (totalCount == 0L) {
+            return GetMonthlyDiaryStatsResult(stats = emptyList())
+        }
+
+        // 각 감정별로 정확한 백분율(소수점 포함)과 기본 정수 백분율을 계산
+        val statsWithRawPercentage = emotionCounts.map {
+            val rawPercentage = (it.count.toDouble() / totalCount.toDouble()) * 100.0
+            Triple(it, rawPercentage, rawPercentage.toInt())
+        }
+
+        // 정수 백분율의 합계를 구해 100과의 차이를 계산
+        val totalIntegerPercentage = statsWithRawPercentage.sumOf { it.third }
+        var remainder = 100 - totalIntegerPercentage
+
+        // 소수점 이하 값이 큰 순서대로 정렬
+        val sortedStats = statsWithRawPercentage.sortedByDescending { it.second - it.third }
+
+        // 최종 통계 리스트를 생성하면서, 소수점 이하 값이 컸던 항목에 나머지 값을 1씩 더함
+        val finalStats = sortedStats.map { (emotionCount, _, basePercentage) ->
+            val finalPercentage = if (remainder > 0) {
+                remainder--
+                basePercentage + 1
+            } else {
+                basePercentage
+            }
+            EmotionStat(
+                emotion = emotionCount.emotion,
+                count = emotionCount.count,
+                percentage = finalPercentage
+            )
+        }
+        val result = finalStats.sortedByDescending { it.count }
+        return GetMonthlyDiaryStatsResult(result)
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/application/service/diary/query/SearchDiariesService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/diary/query/SearchDiariesService.kt
@@ -1,0 +1,24 @@
+package com.soomsoom.backend.application.service.diary.query
+
+import com.soomsoom.backend.application.port.`in`.diary.dto.FindDiaryResult
+import com.soomsoom.backend.application.port.`in`.diary.query.SearchDiariesCriteria
+import com.soomsoom.backend.application.port.`in`.diary.usecase.query.SearchDiariesUseCase
+import com.soomsoom.backend.application.port.out.diary.DiaryPort
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.security.access.prepost.PostAuthorize
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class SearchDiariesService(
+    private val diaryPort: DiaryPort,
+) : SearchDiariesUseCase {
+
+    @PostAuthorize("hasRole('ADMIN') or (#criteria.userId == authentication.principal.id and #criteria.deletionStatus.name() == 'ACTIVE')")
+    override fun search(criteria: SearchDiariesCriteria, pageable: Pageable): Page<FindDiaryResult> {
+        val diaryPage = diaryPort.search(criteria, pageable)
+        return diaryPage.map { FindDiaryResult.from(it) }
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/common/argumentresolvers/pageble/CustomPageableArgumentResolver.kt
+++ b/src/main/kotlin/com/soomsoom/backend/common/argumentresolvers/pageble/CustomPageableArgumentResolver.kt
@@ -67,9 +67,11 @@ class CustomPageableArgumentResolver : HandlerMethodArgumentResolver {
             if (param.isBlank()) return@mapNotNull null // 비어있는 파라미터는 무시
 
             val parts = param.split(",")
-            val field = parts[0]
+            val field = parts[0].trim()
             // 정렬 방향이 없으면 DESC를 기본값으로 사용
-            val direction = parts.getOrNull(1)?.let { Sort.Direction.fromString(it) } ?: Sort.Direction.DESC
+            val direction = parts.getOrNull(1)?.trim()?.let {
+                Sort.Direction.fromString(it.uppercase())
+            } ?: Sort.Direction.DESC
 
             Sort.Order(direction, field)
         }

--- a/src/main/kotlin/com/soomsoom/backend/domain/diary/DiaryErrorCode.kt
+++ b/src/main/kotlin/com/soomsoom/backend/domain/diary/DiaryErrorCode.kt
@@ -1,0 +1,28 @@
+package com.soomsoom.backend.domain.diary
+
+import com.soomsoom.backend.common.exception.ErrorCode
+import org.springframework.context.MessageSource
+import org.springframework.http.HttpStatus
+import java.util.*
+
+enum class DiaryErrorCode(
+    private val httpStatus: HttpStatus,
+    private val messageKey: String,
+) : ErrorCode {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "diary.not-found"),
+    ID_CANNOT_BE_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "diary.id-cannot-be-null"),
+    CREATED_AT_CANNOT_BE_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "diary.created-at-cannot-be-null"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "diary.forbidden"),
+    DIARY_ALREADY_EXISTS(HttpStatus.CONFLICT, "diary.already-exists"),
+    ;
+
+    override val status: HttpStatus
+        get() = this.httpStatus
+
+    override val errorName: String
+        get() = this.name
+
+    override fun message(messageSource: MessageSource): String {
+        return messageSource.getMessage(messageKey, null, Locale.getDefault())
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/domain/diary/model/Diary.kt
+++ b/src/main/kotlin/com/soomsoom/backend/domain/diary/model/Diary.kt
@@ -1,0 +1,34 @@
+package com.soomsoom.backend.domain.diary.model
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class Diary(
+    val id: Long? = null,
+    val userId: Long,
+    var emotion: Emotion,
+    var memo: String?,
+    val recordDate: LocalDate,
+
+    val createdAt: LocalDateTime? = null,
+    val modifiedAt: LocalDateTime? = null,
+    var deletedAt: LocalDateTime? = null,
+) {
+    val isDeleted: Boolean
+        get() = deletedAt != null
+
+    /**
+     * 감정 기록의 감정과 메모를 수정
+     */
+    fun update(emotion: Emotion, memo: String?) {
+        this.emotion = emotion
+        this.memo = memo
+    }
+
+    /**
+     * 감정 기록 삭제 처리(soft delete)
+     */
+    fun delete() {
+        this.deletedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/com/soomsoom/backend/domain/diary/model/Emotion.kt
+++ b/src/main/kotlin/com/soomsoom/backend/domain/diary/model/Emotion.kt
@@ -1,0 +1,10 @@
+package com.soomsoom.backend.domain.diary.model
+
+enum class Emotion {
+    HAPPINESS, // 행복해요
+    JOY, // 좋아요
+    NEUTRAL, // 그냥 그래요
+    DEPRESSION, // 우울해요
+    SADNESS, // 슬퍼요
+    ANGER, // 화나요
+}

--- a/src/main/resources/messages/messages-error.properties
+++ b/src/main/resources/messages/messages-error.properties
@@ -17,3 +17,10 @@ upload.file-key-mismatch="해당 fileKey로 업로드된 파일이 없습니다.
 # activity
 activity.type-unsupported="지원하지 않는 Type입니다."
 activity.not-found="activity를 찾을 수 없습니다."
+
+# diary
+diary.not-found="감정 기록을 찾을 수 없습니다."
+diary.id-cannot-be-null="저장된 감정 기록의 ID가 존재하지 않습니다. (서버 오류)"
+diary.created-at-cannot-be-null="저장된 감정 기록의 생성 일시가 존재하지 않습니다. (서버 오류)"
+diary.forbidden="권한이 없습니다."
+diary.already-exists="이미 해당 날짜에 작성한 감정 기록이 존재합니다."

--- a/src/test/kotlin/com/soomsoom/backend/adapter/out/persistence/activity/repository/ActivityPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/soomsoom/backend/adapter/out/persistence/activity/repository/ActivityPersistenceAdapterTest.kt
@@ -88,10 +88,20 @@ class ActivityPersistenceAdapterTest(
     Given("활성 상태와 삭제된 상태의 활동이 DB에 저장되어 있을 때") {
         // 테스트 데이터 준비
         val activeActivity = activityPersistenceAdapter.save(
-            BreathingActivity(id = null, title = "활성 활동", descriptions = mutableListOf(), authorId = author.id, narratorId = narrator.id, durationInSeconds = 10, thumbnailImageUrl = null, thumbnailFileKey = null, audioUrl = null, audioFileKey = null, timeline = mutableListOf()) // ✨ 수정됨
+            BreathingActivity(
+                id = null, title = "활성 활동", descriptions = mutableListOf(),
+                authorId = author.id, narratorId = narrator.id,
+                durationInSeconds = 10, thumbnailImageUrl = null, thumbnailFileKey = null,
+                audioUrl = null, audioFileKey = null, timeline = mutableListOf()
+            ) // ✨ 수정됨
         )
         val deletedActivity = activityPersistenceAdapter.save(
-            BreathingActivity(id = null, title = "삭제된 활동", descriptions = mutableListOf(), authorId = author.id, narratorId = narrator.id, durationInSeconds = 10, thumbnailImageUrl = null, thumbnailFileKey = null, audioUrl = null, audioFileKey = null, timeline = mutableListOf()) // ✨ 수정됨
+            BreathingActivity(
+                id = null, title = "삭제된 활동", descriptions = mutableListOf(),
+                authorId = author.id, narratorId = narrator.id,
+                durationInSeconds = 10, thumbnailImageUrl = null, thumbnailFileKey = null,
+                audioUrl = null, audioFileKey = null, timeline = mutableListOf()
+            ) // ✨ 수정됨
         ).apply { delete() }
         activityPersistenceAdapter.save(deletedActivity)
 

--- a/src/test/kotlin/com/soomsoom/backend/application/service/activity/command/ChangeActivityThumbnailServiceTest.kt
+++ b/src/test/kotlin/com/soomsoom/backend/application/service/activity/command/ChangeActivityThumbnailServiceTest.kt
@@ -20,7 +20,13 @@ import com.soomsoom.backend.domain.user.FileCategory
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.*
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.spyk
+import io.mockk.verify
 import java.time.LocalDateTime
 
 class ChangeActivityThumbnailServiceTest : BehaviorSpec({

--- a/src/test/kotlin/com/soomsoom/backend/application/service/activity/command/UpdateActivityMetadataServiceTest.kt
+++ b/src/test/kotlin/com/soomsoom/backend/application/service/activity/command/UpdateActivityMetadataServiceTest.kt
@@ -11,7 +11,11 @@ import com.soomsoom.backend.domain.activity.model.MeditationActivity
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.*
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
 import java.time.LocalDateTime
 
 class UpdateActivityMetadataServiceTest : BehaviorSpec({


### PR DESCRIPTION
## ⭐ Issue Number
> close #30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 감정 일기 API 추가: 생성, 단건 조회, 검색(페이지네이션/기간), 수정, 삭제(소프트 삭제), 월별 통계(합계 100% 보장), 일별 기록 조회.
* **보안**
  * JWT에 사용자 ID 클레임 추가 및 인증 주체가 사용자 상세 정보 객체로 복원되어 권한 검증이 강화됨.
* **개선**
  * 검색 정렬 파싱 강건성 향상(공백/대소문자 처리).  
  * 요청 DTO에 입력 검증(필수 필드 메시지) 및 변환 유틸 추가.
  * 영속성·쿼리 계층과 매퍼, 포트/어댑터, 서비스 계층 추가로 일기 도메인 CRUD 및 통계 지원.
* **문서/메시지**
  * 일기 관련 한글 에러 메시지 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->