### PR TITLE
배너 단건 조회 및 어드민 검증 추가, 명상 야간 조건 STREAK에서 COUNT로 변경

### DIFF
--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/banner/BannerController.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/web/api/banner/BannerController.kt
@@ -125,4 +125,12 @@ class BannerController(
     ) {
         deleteBannerUseCase.delete(bannerId)
     }
+
+    @GetMapping("/{bannerId}")
+    @ResponseStatus(HttpStatus.OK)
+    fun findById(
+        @PathVariable bannerId: Long,
+    ): BannerAdminResult {
+        return bannerQueryUseCase.findById(bannerId)
+    }
 }

--- a/src/main/kotlin/com/soomsoom/backend/application/port/in/banner/usecase/query/BannerQueryUseCase.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/port/in/banner/usecase/query/BannerQueryUseCase.kt
@@ -9,4 +9,5 @@ import org.springframework.data.domain.Pageable
 interface BannerQueryUseCase {
     fun findActiveBanners(): List<BannerResult>
     fun findAllBanners(criteria: FindBannersCriteria, pageable: Pageable): Page<BannerAdminResult>
+    fun findById(bannerId: Long): BannerAdminResult
 }

--- a/src/main/kotlin/com/soomsoom/backend/application/service/achievement/command/strategy/MeditationCompletedProgressUpdateStrategy.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/achievement/command/strategy/MeditationCompletedProgressUpdateStrategy.kt
@@ -33,7 +33,7 @@ class MeditationCompletedProgressUpdateStrategy(
         handleStreak(payload, ConditionType.MEDITATION_STREAK)
 
         // 심야 연속
-        handleLateNightStreak(payload)
+        handleLateNightCount(payload)
 
         // 월간 누적
         handleMonthlyCount(payload, ConditionType.MEDITATION_MONTHLY_COUNT)
@@ -65,15 +65,14 @@ class MeditationCompletedProgressUpdateStrategy(
         }
     }
 
-    private fun handleLateNightStreak(payload: ActivityCompletedPayload) {
+    private fun handleLateNightCount(payload: ActivityCompletedPayload) {
         val completedAt = payload.completedAt
-        val type = ConditionType.MEDITATION_LATE_NIGHT_STREAK
+        val type = ConditionType.MEDITATION_LATE_NIGHT_COUNT
 
-        if (completedAt.hour >= 20 || completedAt.hour < 2) { // 20시 ~ 02시 사이
-            handleStreak(payload, type)
-        } else {
-            // 심야 시간이 아니면 연속 기록을 0으로 초기화
-            handleProgress(payload.userId, type) { progress, maxTarget -> progress.updateTo(0, maxTarget) }
+        if (completedAt.hour >= 20 || completedAt.hour < 5) { // 20시 ~ 02시 사이
+            handleProgress(payload.userId, type) { progress, maxTarget ->
+                progress.increase(maxTarget)
+            }
         }
     }
 

--- a/src/main/kotlin/com/soomsoom/backend/application/service/banner/query/FindBannerService.kt
+++ b/src/main/kotlin/com/soomsoom/backend/application/service/banner/query/FindBannerService.kt
@@ -10,6 +10,7 @@ import com.soomsoom.backend.application.port.out.activity.ActivityPort
 import com.soomsoom.backend.application.port.out.banner.BannerPort
 import com.soomsoom.backend.common.exception.SoomSoomException
 import com.soomsoom.backend.domain.activity.ActivityErrorCode
+import com.soomsoom.backend.domain.banner.BannerErrorCode
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.security.access.prepost.PreAuthorize
@@ -50,5 +51,15 @@ class FindBannerService(
                 ?: throw SoomSoomException(ActivityErrorCode.NOT_FOUND)
             banner.toAdminResult(activity)
         }
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    override fun findById(bannerId: Long): BannerAdminResult {
+        val banner = bannerPort.findById(bannerId)
+            ?: throw SoomSoomException(BannerErrorCode.NOT_FOUND)
+        val activity = activityPort.findById(banner.linkedActivityId)
+            ?: throw SoomSoomException(ActivityErrorCode.NOT_FOUND)
+
+        return banner.toAdminResult(activity)
     }
 }

--- a/src/main/kotlin/com/soomsoom/backend/domain/achievement/model/enums/ConditionType.kt
+++ b/src/main/kotlin/com/soomsoom/backend/domain/achievement/model/enums/ConditionType.kt
@@ -11,7 +11,7 @@ enum class ConditionType {
     // 명상 관련
     MEDITATION_COUNT, // 총 명상 완료 횟수
     MEDITATION_STREAK, // 연속 명상 완료일 수
-    MEDITATION_LATE_NIGHT_STREAK, // 심야(20시~02시) 명상 연속 완료일 수
+    MEDITATION_LATE_NIGHT_COUNT, // 심야(20시~02시) 명상 연속 완료일 수
     MEDITATION_MONTHLY_COUNT, // 월간 명상 완료 횟수
     MEDITATION_TOTAL_MINUTES, // 명상 총 시간(분)
 
@@ -91,7 +91,7 @@ enum class ConditionType {
                 descriptionKey = "achievement.condition.MEDITATION_STREAK",
                 progressUnitKey = ACHIEVEMENT_UNIT_DAY
             ),
-            MEDITATION_LATE_NIGHT_STREAK to DisplayProperties(
+            MEDITATION_LATE_NIGHT_COUNT to DisplayProperties(
                 descriptionKey = "achievement.condition.MEDITATION_LATE_NIGHT_STREAK",
                 progressUnitKey = ACHIEVEMENT_UNIT_DAY
             ),

--- a/src/main/resources/db/migration/V2__achivement_conditions_update.ddl
+++ b/src/main/resources/db/migration/V2__achivement_conditions_update.ddl
@@ -1,0 +1,53 @@
+-- V2__modify_achievement_conditions_for_late_night_count.sql
+
+-- 1단계: 새로운 ENUM 값('MEDITATION_LATE_NIGHT_COUNT')을 기존 목록에 추가합니다.
+-- 이렇게 하면 기존 데이터는 유지한 채로 새로운 값으로 UPDATE가 가능해집니다.
+ALTER TABLE achievement_conditions
+    MODIFY COLUMN type ENUM (
+        'BREATHING_COUNT',
+        'BREATHING_MONTHLY_COUNT',
+        'BREATHING_MULTI_TYPE_COUNT',
+        'BREATHING_STREAK',
+        'BREATHING_TOTAL_MINUTES',
+        'DIARY_COUNT',
+        'DIARY_MONTHLY_COUNT',
+        'DIARY_STREAK',
+        'HIDDEN_CUSTOMIZE_CHARACTER',
+        'HIDDEN_EMOTION_OVERCOME',
+        'HIDDEN_STAY_HOME_SCREEN',
+        'MEDITATION_COUNT',
+        'MEDITATION_LATE_NIGHT_STREAK', -- 아직 삭제하지 않음
+        'MEDITATION_LATE_NIGHT_COUNT',  -- 새로운 값 추가
+        'MEDITATION_MONTHLY_COUNT',
+        'MEDITATION_STREAK',
+        'MEDITATION_TOTAL_MINUTES',
+        'SOUND_EFFECT_TOTAL_MINUTES'
+        );
+
+-- 2단계: 기존의 'MEDITATION_LATE_NIGHT_STREAK' 데이터를 새로운 'MEDITATION_LATE_NIGHT_COUNT'로 모두 업데이트합니다.
+UPDATE achievement_conditions
+SET type = 'MEDITATION_LATE_NIGHT_COUNT'
+WHERE type = 'MEDITATION_LATE_NIGHT_STREAK';
+
+-- 3단계: 이제 사용하지 않는 'MEDITATION_LATE_NIGHT_STREAK' 값을 ENUM 목록에서 최종적으로 제거합니다.
+ALTER TABLE achievement_conditions
+    MODIFY COLUMN type ENUM (
+        'BREATHING_COUNT',
+        'BREATHING_MONTHLY_COUNT',
+        'BREATHING_MULTI_TYPE_COUNT',
+        'BREATHING_STREAK',
+        'BREATHING_TOTAL_MINUTES',
+        'DIARY_COUNT',
+        'DIARY_MONTHLY_COUNT',
+        'DIARY_STREAK',
+        'HIDDEN_CUSTOMIZE_CHARACTER',
+        'HIDDEN_EMOTION_OVERCOME',
+        'HIDDEN_STAY_HOME_SCREEN',
+        'MEDITATION_COUNT',
+        -- 'MEDITATION_LATE_NIGHT_STREAK', -- 여기서 제거
+        'MEDITATION_LATE_NIGHT_COUNT',
+        'MEDITATION_MONTHLY_COUNT',
+        'MEDITATION_STREAK',
+        'MEDITATION_TOTAL_MINUTES',
+        'SOUND_EFFECT_TOTAL_MINUTES'
+        );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 관리자용 배너 상세 조회 API 추가(배너 ID로 조회, 권한 필요)

- 리팩터
  - 야간 명상 달성 조건을 ‘연속’에서 ‘횟수’ 기준으로 변경
  - 야간 시간대를 20:00~05:00로 확장
  - 해당 시간대에는 초기화 없이 목표치까지 진행도 누적

- 작업
  - 달성 조건 타입 변경에 따른 데이터 마이그레이션 수행(기존 값 보존 및 일관성 확보)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->