### PR TITLE
chore: ec2에서 s3에 관한 권한 추가

### DIFF
--- a/terraform/modules/app/iam.tf
+++ b/terraform/modules/app/iam.tf
@@ -56,7 +56,11 @@ resource "aws_iam_policy" "s3_write_policy" {
         Version = "2012-10-17",
         Statement = [
             {
-                Action   = "s3:PutObject",
+                Action   = [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject"
+                ]
                 Effect   = "Allow",
                 Resource = "arn:aws:s3:::soomsoom-${var.environment}-bucket/*" # <-- 여기에 실제 버킷 이름을 입력하세요.
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새로운 기능
  * S3 버킷에 대한 권한 범위를 확장했습니다. 이제 애플리케이션이 버킷 객체를 조회(Get), 업로드(Put), 삭제(Delete)할 수 있습니다. 기존 업로드 기능은 유지되며, 추가된 권한으로 파일 미리보기, 상태 확인, 불필요한 객체 정리 등의 작업이 원활해집니다. 접근 대상 리소스 범위는 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->