### PR TITLE
/app-ads.txt 무인증 허용 및 정적 app-ads.txt 추가

### DIFF
--- a/src/main/kotlin/com/soomsoom/backend/adapter/in/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/soomsoom/backend/adapter/in/security/config/SecurityConfig.kt
@@ -47,7 +47,8 @@ class SecurityConfig(
                         "/auth/logout",
                         "/callbacks/admob/ssv",
                         "/app-versions/check",
-                        "/actuator/health"
+                        "/actuator/health",
+                        "/app-ads.txt"
                     ).permitAll()
 
                 domainSecurityConfigurer.forEach { it.configure(authorize) }

--- a/src/main/resources/static/app-ads.txt
+++ b/src/main/resources/static/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-4758709448782249, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## ⭐ Issue Number
> close #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * /app-ads.txt 경로를 공개 엔드포인트로 허용하여 인증 없이 접근 가능하도록 했습니다. 기존 보안 동작에는 영향이 없습니다.
* 잡무
  * app-ads.txt 정적 리소스를 추가하여 클라이언트와 크롤러가 해당 경로에서 정보를 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->