### PR TITLE
Change achievement display unit from hours to minutes

### DIFF
--- a/src/main/kotlin/com/soomsoom/backend/domain/achievement/model/enums/ConditionType.kt
+++ b/src/main/kotlin/com/soomsoom/backend/domain/achievement/model/enums/ConditionType.kt
@@ -111,8 +111,8 @@ enum class ConditionType {
             ),
             HIDDEN_STAY_HOME_SCREEN to DisplayProperties(
                 descriptionKey = "achievement.condition.HIDDEN_STAY_HOME_SCREEN",
-                progressUnitKey = ACHIEVEMENT_UNIT_HOUR,
-                descriptionDivisor = HOUR_DIVISOR,
+                progressUnitKey = ACHIEVEMENT_UNIT_MINUTE,
+                descriptionDivisor = MINUTE_DIVISOR,
                 progressDivisor = MINUTE_DIVISOR
             ),
             HIDDEN_EMOTION_OVERCOME to DisplayProperties(


### PR DESCRIPTION
- 분 -> 시간

## ⭐ Issue Number
> close #124


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 성취도 진행률 표시 단위를 시간 단위에서 분 단위로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->